### PR TITLE
README.md: Fix the Matrix address

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Copyright (c) 2020-2022, The Monero Project.
 * Reddit: [/r/FeatherWallet](https://old.reddit.com/r/FeatherWallet)
 * Mail: dev@featherwallet.org
 * IRC: `#feather` on OFTC
-* Matrix: `#_oftc_#feather:matrix.org`
+* Matrix: `#feather:monero.social`
 
 Download the latest release [here](https://featherwallet.org/download).
 


### PR DESCRIPTION
There is a plumbed room at #feather:monero.social, while `#_oftc_#fether:matrix.org` is a portal room. This is problematic because it results in two Matrix rooms bridged to the same IRC. `#feather:monero.social` has significantly more users, so switch to that in the README to avoid new users joining the portal room.