### PR TITLE
Portable mode: set ringdb path to portable path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(DEBUG)
     set(CMAKE_VERBOSE_MAKEFILE ON)
 endif()
 
-set(MONERO_HEAD "2ab81abe7bea16f0f6da55da3b212f9ffbca8dcd")
+set(MONERO_HEAD "4982ac420c101be2afb387138c4ee57b1a5c2f9b")
 set(BUILD_GUI_DEPS ON)
 option(ARCH "Target architecture" "native")
 set(BUILD_64 ON)

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -159,7 +159,7 @@ void Settings::setupNodeTab() {
 void Settings::setupPathsTab() {
     ui->lineEdit_defaultWalletDir->setText(config()->get(Config::walletDirectory).toString());
     ui->lineEdit_configDir->setText(Config::defaultConfigDir().path());
-    ui->lineEdit_applicationDir->setText(QCoreApplication::applicationDirPath());
+    ui->lineEdit_applicationDir->setText(Utils::applicationPath());
 
     connect(ui->btn_browseDefaultWalletDir, &QPushButton::clicked, [this]{
         QString walletDirOld = config()->get(Config::walletDirectory).toString();

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -156,7 +156,7 @@ void WindowManager::tryOpenWallet(const QString &path, const QString &password) 
     }
 
     m_openingWallet = true;
-    m_walletManager->openWalletAsync(path, password, constants::networkType, 1);
+    m_walletManager->openWalletAsync(path, password, constants::networkType, constants::kdfRounds, Utils::ringDatabasePath());
 }
 
 void WindowManager::onWalletOpened(Wallet *wallet) {

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -9,6 +9,7 @@
 #include "model/AddressBookModel.h"
 #include "model/TransactionHistoryModel.h"
 #include "utils/brute.h"
+#include "utils/Utils.h"
 #include "constants.h"
 
 CLI::CLI(Mode mode, QCommandLineParser *cmdargs, QObject *parent)
@@ -34,7 +35,7 @@ CLI::CLI(Mode mode, QCommandLineParser *cmdargs, QObject *parent)
         QString password = cmdargs->value("password");
 
 
-        m_walletManager->openWalletAsync(walletFile, password, constants::networkType);
+        m_walletManager->openWalletAsync(walletFile, password, constants::networkType, constants::kdfRounds, Utils::ringDatabasePath());
     }
     else if (mode == Mode::BruteforcePassword)
     {

--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -74,7 +74,7 @@ Wallet *WalletManager::createWallet(const QString &path, const QString &password
     return new Wallet(w);
 }
 
-Wallet *WalletManager::openWallet(const QString &path, const QString &password, NetworkType::Type nettype, quint64 kdfRounds)
+Wallet *WalletManager::openWallet(const QString &path, const QString &password, NetworkType::Type nettype, quint64 kdfRounds, const QString &ringDatabasePath)
 {
     QMutexLocker locker(&m_mutex);
     WalletPassphraseListenerImpl tmpListener(this);
@@ -88,7 +88,7 @@ Wallet *WalletManager::openWallet(const QString &path, const QString &password, 
 
     qDebug() << QString("%1: opening wallet at %2, nettype = %3 ").arg(__PRETTY_FUNCTION__).arg(qPrintable(path)).arg(nettype);
 
-    Monero::Wallet * w =  m_pimpl->openWallet(path.toStdString(), password.toStdString(), static_cast<Monero::NetworkType>(nettype), kdfRounds, &tmpListener);
+    Monero::Wallet * w = m_pimpl->openWallet(path.toStdString(), password.toStdString(), static_cast<Monero::NetworkType>(nettype), kdfRounds, ringDatabasePath.toStdString(), &tmpListener);
     w->setListener(nullptr);
 
     qDebug() << QString("%1: opened wallet: %2, status: %3").arg(__PRETTY_FUNCTION__).arg(w->address(0, 0).c_str()).arg(w->status());
@@ -102,10 +102,10 @@ Wallet *WalletManager::openWallet(const QString &path, const QString &password, 
     return wallet;
 }
 
-void WalletManager::openWalletAsync(const QString &path, const QString &password, NetworkType::Type nettype, quint64 kdfRounds)
+void WalletManager::openWalletAsync(const QString &path, const QString &password, NetworkType::Type nettype, quint64 kdfRounds, const QString &ringDatabasePath)
 {
-    m_scheduler.run([this, path, password, nettype, kdfRounds] {
-        emit walletOpened(openWallet(path, password, nettype, kdfRounds));
+    m_scheduler.run([this, path, password, nettype, kdfRounds, ringDatabasePath] {
+        emit walletOpened(openWallet(path, password, nettype, kdfRounds, ringDatabasePath));
     });
 }
 

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -35,13 +35,13 @@ public:
      * \param nettype    - type of network the wallet is running on
      * \return wallet object pointer
      */
-    Wallet * openWallet(const QString &path, const QString &password, NetworkType::Type nettype = NetworkType::MAINNET, quint64 kdfRounds = 1);
+    Wallet * openWallet(const QString &path, const QString &password, NetworkType::Type nettype = NetworkType::MAINNET, quint64 kdfRounds = 1, const QString &ringDatabasePath = "");
 
     /*!
      * \brief openWalletAsync - asynchronous version of "openWallet". Returns immediately. "walletOpened" signal
      *                          emitted when wallet opened;
      */
-    void openWalletAsync(const QString &path, const QString &password, NetworkType::Type nettype = NetworkType::MAINNET, quint64 kdfRounds = 1);
+    void openWalletAsync(const QString &path, const QString &password, NetworkType::Type nettype = NetworkType::MAINNET, quint64 kdfRounds = 1, const QString &ringDatabasePath = "");
 
     Wallet * recoveryWallet(const QString &path, const QString &password, const QString &seed, const QString &seed_offset,
                             NetworkType::Type nettype = NetworkType::MAINNET, quint64 restoreHeight = 0, quint64 kdfRounds = 1);

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -21,8 +21,12 @@ namespace Utils
     bool pixmapWrite(const QString &path, const QPixmap &pixmap);
     QStringList fileFind(const QRegularExpression &pattern, const QString &baseDir, int level, int depth, int maxPerDir);
 
-    bool dirExists(const QString &path);
+    QString portablePath();
+    bool isPortableMode();
     bool portableFileExists(const QString &dir);
+    QString ringDatabasePath();
+
+    bool dirExists(const QString &path);
     QString defaultWalletDir();
     QString applicationPath();
 

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -168,9 +168,8 @@ Config::Config(QObject* parent)
 }
 
 QDir Config::defaultConfigDir() {
-    QString portablePath = QCoreApplication::applicationDirPath();
-    if (Utils::portableFileExists(portablePath)) {
-        return portablePath + "/feather_data";
+    if (Utils::isPortableMode()) {
+        return Utils::portablePath();
     }
 
     if (TailsOS::detect()) {
@@ -202,10 +201,6 @@ QDir Config::defaultConfigDir() {
 #else
     return QDir(QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/feather");
 #endif
-}
-
-QDir Config::defaultPortableConfigDir() {
-    return QDir(QCoreApplication::applicationDirPath() + "/feather_data");
 }
 
 Config::~Config()

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -123,7 +123,6 @@ public:
     void resetToDefaults();
 
     static QDir defaultConfigDir();
-    static QDir defaultPortableConfigDir();
 
     static Config* instance();
 


### PR DESCRIPTION
This is arguably better than `~/.shared-ringdb` for two reasons:

- Some users might want all files written by Feather to go to `feather_data` in portable mode. (E.g. when stored on an encrypted volume, leaving as little trace on the system's filesystem as possible).
- The installation might be used on a different computer (this is portable mode, after all). Having ringdb available here to cache rings between sessions is more important than cross-chain key reuse mitigations.