### PR TITLE
WebSocketClient: Replace 'error' with 'errorOccured'

### DIFF
--- a/src/utils/WebsocketClient.cpp
+++ b/src/utils/WebsocketClient.cpp
@@ -15,7 +15,7 @@ WebsocketClient::WebsocketClient(QObject *parent)
     connect(webSocket, &QWebSocket::stateChanged, this, &WebsocketClient::onStateChanged);
     connect(webSocket, &QWebSocket::connected, this, &WebsocketClient::onConnected);
     connect(webSocket, &QWebSocket::disconnected, this, &WebsocketClient::onDisconnected);
-    connect(webSocket, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error), this, &WebsocketClient::onError);
+    connect(webSocket, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::errorOccured), this, &WebsocketClient::onError);
 
     connect(webSocket, &QWebSocket::binaryMessageReceived, this, &WebsocketClient::onbinaryMessageReceived);
 


### PR DESCRIPTION
`error` is deprecated since 5.15 and replaced by `errorOccured`

https://doc.qt.io/qt-6/qabstractsocket.html#errorOccurred

```
warning: ‘void QWebSocket::error(QAbstractSocket::SocketError)’ is deprecated: Use errorOccurred instead [-Wdeprecated-declarations]
   15 |   connect(webSocket, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error), this, &WebsocketClient::onError);
      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
In file included from /home/dsc/Qt6/6.6.1/gcc_64/include/QtWebSockets/QWebSocket:1,
                 from /home/dsc/bla/lib/wsclient.h:2,
                 from /home/dsc/bla/lib/wsclient.cpp:3:
/home/dsc/Qt6/6.6.1/gcc_64/include/QtWebSockets/qwebsocket.h:132:10: note: declared here
  132 |     void error(QAbstractSocket::SocketError error);
```