### PR TITLE
Make 3 Monero variables more available to the Feather makefile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ get_directory_property(ARCH_WIDTH DIRECTORY "monero" DEFINITION ARCH_WIDTH)
 get_directory_property(UNBOUND_LIBRARY DIRECTORY "monero" DEFINITION UNBOUND_LIBRARY)
 get_directory_property(DEVICE_TREZOR_READY DIRECTORY "monero" DEFINITION DEVICE_TREZOR_READY)
 get_directory_property(TREZOR_DEP_LIBS DIRECTORY "monero" DEFINITION TREZOR_DEP_LIBS)
+get_directory_property(OPENBSD DIRECTORY "monero" DEFINITION OPENBSD)
+get_directory_property(FREEBSD DIRECTORY "monero" DEFINITION FREEBSD)
+get_directory_property(DRAGONFLY DIRECTORY "monero" DEFINITION DRAGONFLY)
 
 # libXau
 # workaround for: undefined reference to `XauGetBestAuthByAddr'


### PR DESCRIPTION
Get 3 variable values more from Monero's `CMakeLists.txt` that are used by Feather's own `CMakeLists.txt` but were never set so far.

Compiling for OpenBSD failed for that reason, as some things for Feather on OpenBSD must be done in a certain way while building, but with the `OPENBSD` variable value not picked from Monero that does not work.
