### PR TITLE
wizard: Automatically add space when autocompleting words

### DIFF
--- a/src/wizard/PageWalletRestoreSeed.h
+++ b/src/wizard/PageWalletRestoreSeed.h
@@ -48,9 +48,12 @@ private:
     void onSeedTypeToggled();
     void onSeedLanguageChanged(const QString &language);
     void onOptionsClicked();
+    void onCompleterActiviated(const QString &text);
 
     Ui::PageWalletRestoreSeed *ui;
     WizardFields *m_fields;
+    bool m_wordAutocompleted;
+    int m_needCursorMove;
 
     seedType m_polyseed;
     seedType m_tevador;


### PR DESCRIPTION
Attempt to add a space after each word and advance the cursor when a user uses the autocomplete to select it. Doesn't add spaces if there is already a space in front of it.

I have barely touched QT before so this might be a bit ugly. Let me know if there is a better way of doing this.
