### PR TITLE
Add .desktop file keywords entries.

### DIFF
--- a/src/assets/feather.desktop
+++ b/src/assets/feather.desktop
@@ -9,3 +9,4 @@ Terminal=false
 Categories=Network;
 StartupNotify=false
 StartupWMClass=feather
+Keywords=crypto;currency;XMR


### PR DESCRIPTION
I am in the process of packaging Feather Wallet for inclusion in Debian's official repositories.  One of the things that Debian's packaging system checks for is that .desktop files have keyword entries, which are words that users can search for to find program in addition to those contained in the `Name` and `GenericName` fields.

I have added a few keywords that made sense for Feather Wallet, although there are probably others that people could come up with.