### PR TITLE
Add an AppStream MetaInfo file.

### DIFF
--- a/src/assets/org.featherwallet.feather.metainfo.xml
+++ b/src/assets/org.featherwallet.feather.metainfo.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>org.featherwallet.feather.desktop</id>
+    <name>Feather</name>
+    <summary>Monero desktop wallet</summary>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>BSD-3-Clause</project_license>
+    <categories>
+        <category>Network</category>
+        <category>Qt</category>
+        <category>Finance</category>
+        <category>Office</category>
+    </categories>
+    <description>
+        <p>Feather is a Monero wallet for the desktop (with a GUI built on Qt)
+            with the following features:</p>
+        <ul>
+            <li>
+                Easy-to-use, small and fast - Feather
+                runs well on any modern hardware, including virtual machines
+                and live operating systems.
+            </li>
+            <li>
+                Beginner friendly, but also caters to advanced Monero
+                users by providing a feature set that is on par with the official CLI.
+            </li>
+            <li>
+                Ships with sane defaults that suit most users, but
+                can also be configured for high or uncommon threat models.
+            </li>
+            <li>
+                Serves as a testing grounds for experimental features
+                that may later be adopted in the reference wallets.
+            </li>
+        </ul>
+    </description>
+    <launchable type="desktop-id">feather.desktop</launchable>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://featherwallet.org/img/receive_light.png</image>
+            <caption>The main Feather Wallet window.</caption>
+        </screenshot>
+    </screenshots>
+    <url type="homepage">https://featherwallet.org/</url>
+    <url type="bugtracker">https://github.com/feather-wallet/feather</url>
+    <url type="donation">https://docs.featherwallet.org/guides/donate</url>
+    <url type="contact">https://docs.featherwallet.org/guides/report-an-issue</url>
+    <url type="help">https://docs.featherwallet.org</url>
+    <url type="vcs-browser">https://github.com/feather-wallet/feather</url>
+
+    <developer id="org.featherwallet">
+        <name>The Monero Project</name>
+    </developer>
+
+    <content_rating type="oars-1.1" />
+</component>


### PR DESCRIPTION
In preparing the Debian package, I noticed that there was an AppStream MetaInfo file in:

https://github.com/feather-wallet/feather/tree/master/contrib/flatpak/share/metainfo

However, the desktop-id of this file is not compatible with the feather.desktop file at:

https://github.com/feather-wallet/feather/blob/master/src/assets/feather.desktop

I didn't want to edit the flatpak version as doing so might break the flatpak installation in ways I couldn't foresee.  Instead, I have created a new version of the file.

Beyond making it compatible with feather.desktop, I have also fixed the following issued identified by `appstreamcli`.

```
I: org.featherwallet.Feather:15: description-first-para-too-short
     Feather is a Monero wallet for desktop with the following features:
I: org.featherwallet.Feather:~: content-rating-missing
I: org.featherwallet.Feather:~: developer-info-missing
P: org.featherwallet.Feather:3: cid-contains-uppercase-letter org.featherwallet.Feather
P: org.featherwallet.Feather:38: screenshot-no-caption
```

https://freedesktop.org/software/appstream/docs/chap-Validation.html