### PR TITLE
Generate Feather icon for .desktop in local dir

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -8,6 +8,9 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QCheckBox>
+#include <QFile>
+#include <QDir>
+#include <QStandardPaths>
 
 #include "constants.h"
 #include "dialog/AddressCheckerIndexDialog.h"
@@ -35,6 +38,7 @@
 #include "utils/Icons.h"
 #include "utils/TorManager.h"
 #include "utils/WebsocketNotifier.h"
+#include "utils/Utils.h"
 
 #include "wallet/wallet_errors.h"
 
@@ -79,7 +83,7 @@ MainWindow::MainWindow(WindowManager *windowManager, Wallet *wallet, QWidget *pa
 
     this->onOfflineMode(conf()->get(Config::offlineMode).toBool());
     conf()->set(Config::restartRequired, false);
-    
+
     // Websocket notifier
 #ifdef CHECK_UPDATES
     connect(websocketNotifier(), &WebsocketNotifier::UpdatesReceived, m_updater.data(), &Updater::wsUpdatesReceived);
@@ -127,6 +131,20 @@ MainWindow::MainWindow(WindowManager *windowManager, Wallet *wallet, QWidget *pa
     connect(&m_checkUserActivity, &QTimer::timeout, this, &MainWindow::checkUserActivity);
     m_checkUserActivity.setInterval(5000);
     m_checkUserActivity.start();
+    
+    // Call the setupIcon function during initialization
+    this->setupIcon();
+}
+
+void MainWindow::setupIcon() {
+#ifdef Q_OS_LINUX
+    QString iconSource = ":/assets/images/appicons/appicon.svg";
+    QString iconDestination = Utils::getDefaultIconPath();
+
+    if (!Utils::copyIconToUserFolder(iconSource, iconDestination)) {
+        QMessageBox::warning(this, tr("Icon Setup Failed"), tr("Failed to copy the application icon to the user folder."));
+    }
+#endif
 }
 
 void MainWindow::initStatusBar() {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -216,6 +216,9 @@ private:
     QIcon hardwareDevicePairedIcon();
     QIcon hardwareDeviceUnpairedIcon();
 
+    // Add the function declaration for setupIcon
+    void setupIcon();
+
     QScopedPointer<Ui::MainWindow> ui;
     WindowManager *m_windowManager;
     Wallet *m_wallet = nullptr;

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -15,6 +15,8 @@
 #include <QLayoutItem>
 #include <QJsonDocument>
 #include <QThread>
+#include <QDir>
+#include <QFile>
 #include <QStandardPaths>
 #include <QProcess>
 
@@ -130,6 +132,26 @@ QString getSaveFileName(QWidget* parent, const QString &caption, const QString &
     QFileInfo fileInfo(fn);
     conf()->set(Config::lastPath, fileInfo.absolutePath());
     return fn;
+}
+
+bool Utils::copyIconToUserFolder(const QString &sourcePath, const QString &destinationPath) {
+    QDir dir(destinationPath);
+    if (!dir.exists()) {
+        dir.mkpath(".");
+    }
+
+    QFile file(sourcePath);
+    if (!file.exists()) {
+        return false;
+    }
+
+    QString destFilePath = destinationPath + "/feather.svg";
+    QFile::remove(destFilePath); // Remove if it already exists to avoid copy failure
+    return file.copy(destFilePath);
+}
+
+QString Utils::getDefaultIconPath() {
+    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/icons/hicolor/scalable/apps";
 }
 
 QString getOpenFileName(QWidget* parent, const QString& caption, const QString& filter) {

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -121,6 +121,10 @@ namespace Utils
     QString formatSyncStatus(quint64 height, quint64 target, bool daemonSync = false);
 
     QString getVersion();
+
+    // Copy Icon for local .desktop file
+    bool copyIconToUserFolder(const QString &sourcePath, const QString &destinationPath);
+    QString getDefaultIconPath();
 }
 
 #endif //FEATHER_UTILS_H


### PR DESCRIPTION
Aesthetics: Desktop icon not visible via Tails #222

These commits add the necessary functions for copying the icon to `~/.local/share/icons/hicolor/scalable/apps/` and updating the generation of the `.desktop` file to have the correct path. The setupIcon function is called during the initialization of the MainWindow class to ensure the icon is copied correctly.

## Commit 1: 1e8045649c38c076aac516e6f236df6dd80daa6c

This commit adds the copyIconToUserFolder and getDefaultIconPath functions to Utils.cpp.

## Commit 2: eab5f159b8bcd74a17acf99ff6111ae3130f0ff8

This commit updates Utils.h to include the declarations for copyIconToUserFolder and getDefaultIconPath.


## Commit 3: 9f7871827544b19cd21974aceddfef30c141224f

This commit updates MainWindow.cpp to include the setupIcon function and calls it in the constructor.

## Commit 4: c023bd41d1ddcde17b52c64cf8f9eef60f03d0a0

This commit updates MainWindow.h to include the declaration for setupIcon.