### PR TITLE
nodes.json: Add nodes from stormycloud

### DIFF
--- a/src/assets/nodes.json
+++ b/src/assets/nodes.json
@@ -19,13 +19,15 @@
       "sfprpc2fws6ltnq4hyr7lvpul3nank5layd7q7tyc5h4gy4h77gtabad.onion:18089",
       "4kzkwyooeth3lxajxs7pmcriq6cgvnbex2vojum2uqflczsci4dlreyd.onion:18089",
       "trocadorh642rks54sxufwy4kys23mrsgof3axowyro5ljb2dkgdlmad.onion:18089",
-      "moneroxmrxw44lku6qniyarpwgznpcwml4drq7vb24ppatlcg4kmxpqd.onion:18089"
+      "moneroxmrxw44lku6qniyarpwgznpcwml4drq7vb24ppatlcg4kmxpqd.onion:18089",
+      "a6orjo6aiotog3njppja5jwnd3rexzfjiejxnojvw74p3kma45fundid.onion:18089"
     ],
     "i2p": [
       "ofrnxmr5ltaazarexs3damrcsldc5p6qlcos3vk25cwdgyjvrueq.b32.i2p:18089",
       "vdmnehdjkpkg57nthgnjfuaqgku673r5bpbqg56ix6fyqoywgqrq.b32.i2p:18089",
       "uqj3aphckqtjsitz7kxx5flqpwjlq5ppr3chazfued7xucv3nheq.b32.i2p:18089",
-      "ugnlcdciyhghh2zert7c3kl4biwkirc43ke33jiy5slnd3mv2trq.b32.i2p:18089"
+      "ugnlcdciyhghh2zert7c3kl4biwkirc43ke33jiy5slnd3mv2trq.b32.i2p:18089",
+      "5dmhmmaff5mqkgmz4haq5w2wrgobhelrat7lvbt27okojkzbx6hq.b32.i2p:18089"
     ],
     "clearnet": [
       "node3-us.monero.love:18081",


### PR DESCRIPTION
Using address book may cause security issue (i.e. `xmr.stormycloud.i2p`), better to use base32 address instead.

Closes #253 