### PR TITLE
Don't pretend to fall off the end of Nodes::useSocks5Proxy()

### DIFF
--- a/src/utils/nodes.cpp
+++ b/src/utils/nodes.cpp
@@ -479,7 +479,8 @@ bool Nodes::useSocks5Proxy(const FeatherNode &node) {
         return false;
     }
 
-    if (conf()->get(Config::proxy).toInt() == Config::Proxy::None) {
+    const auto config_proxy = conf()->get(Config::proxy).toInt();
+    if (config_proxy == Config::Proxy::None) {
         return false;
     }
 
@@ -492,14 +493,12 @@ bool Nodes::useSocks5Proxy(const FeatherNode &node) {
         return true;
     }
 
-    if (conf()->get(Config::proxy).toInt() == Config::Proxy::Tor) {
+    if (config_proxy == Config::Proxy::Tor) {
         // Don't use socks5 proxy if initial sync traffic is excluded.
         return this->useOnionNodes();
     }
 
-    if (conf()->get(Config::proxy).toInt() != Config::Proxy::None) {
-        return true;
-    }
+    return true;
 }
 
 void Nodes::updateModels() {


### PR DESCRIPTION
```
[334/404] Building CXX object src/CMakeFiles/feather.dir/utils/nodes.cpp.o /home/nabijaczleweli/uwu/feather/src/utils/nodes.cpp:503:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
  503 | }
      | ^
1 warning generated.
```