### PR TITLE
Remove contradiction "All rights reserved." in `LICENSE`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,5 @@
 Copyright (c) 2020-2025, The Monero Project
 
-All rights reserved.
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
“All rights reserved” contradicts with the BSD 3-Clause License as it explicitly offers rights to the user: “Redistribution and use in source and binary forms, with or without modification, are permitted…”