### PR TITLE
fix: prevent integer underflow in amount() bounds check

### DIFF
--- a/src/libwalletqt/UnsignedTransaction.cpp
+++ b/src/libwalletqt/UnsignedTransaction.cpp
@@ -19,7 +19,7 @@ QString UnsignedTransaction::errorString() const
 quint64 UnsignedTransaction::amount(size_t index) const
 {
     std::vector<uint64_t> arr = m_pimpl->amount();
-    if(index > arr.size() - 1)
+    if(arr.empty() || index >= arr.size())
         return 0;
     return arr[index];
 }


### PR DESCRIPTION
The bounds check `index > arr.size() - 1` has an edge case bug. When `arr.size()` is `0`, subtracting `1` from an unsigned `size_t` underflows to `SIZE_MAX`, so `index > SIZE_MAX` is always false.

This could theoretically allow out-of-bounds access, though it's pretty hard to trigger in practice - would need a malformed/corrupted unsigned_tx file that parses successfully but has no transactions.

Changed to `arr.empty() || index >= arr.size()` which handles the edge case properly.

Found with AddressSanitizer during fuzzing.