### PR TITLE
wizard: fix incorrect variable usage in key image export

### DIFF
--- a/src/wizard/offline_tx_signing/PageOTS_ExportKeyImages.cpp
+++ b/src/wizard/offline_tx_signing/PageOTS_ExportKeyImages.cpp
@@ -53,9 +53,7 @@ void PageOTS_ExportKeyImages::exportKeyImages() {
 }
 
 void PageOTS_ExportKeyImages::setupUR(bool all) {
-    // TODO: check if empty
-    std::string ki_export;
-    m_wallet->exportKeyImagesToStr(ki_export, all);
+    m_wallet->exportKeyImagesToStr(m_wizardFields->keyImages, all);
     ui->widget_UR->setData("xmr-keyimage", m_wizardFields->keyImages);
 }
 


### PR DESCRIPTION
In PageOTS_ExportKeyImages.cpp, the `setupUR()` function was exporting key images to a local variable `ki_export` but then passing the uninitialized `m_wizardFields->keyImages` to `setData()`. This resulted in the UR widget displaying empty data.

Changed to export directly to `m_wizardFields->keyImages`, matching the pattern used in `PageOTS_ExportOutputs::setupUR()`. This also ensures the data is properly available when `exportKeyImages()` writes to file.

Fixes TODO at PageOTS_ExportKeyImages.cpp:56