### PR TITLE
Data Saving Mode Feature

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -324,7 +324,6 @@ void MainWindow::initMenu() {
     connect(ui->actionRefresh_tabs,          &QAction::triggered, [this]{m_wallet->refreshModels();});
     connect(ui->actionRescan_spent,          &QAction::triggered, this, &MainWindow::rescanSpent);
     connect(ui->actionWallet_cache_debug,    &QAction::triggered, this, &MainWindow::showWalletCacheDebugDialog);
-    connect(ui->actionSkip_sync,             &QAction::triggered, this, &MainWindow::onSkipSync);
     connect(ui->actionSync_dates,            &QAction::triggered, this, &MainWindow::onSyncDates);
     connect(ui->actionFull_sync,             &QAction::triggered, this, &MainWindow::onFullSync);
     connect(ui->actionTxPoolViewer,          &QAction::triggered, this, &MainWindow::showTxPoolViewerDialog);
@@ -496,7 +495,6 @@ void MainWindow::initWalletContext() {
 
     // Wallet
     connect(m_wallet, &Wallet::connectionStatusChanged, [this](int status){
-        // Order is important, first inform UI about a potential disconnect, then reconnect
         this->onConnectionStatusChanged(status);
         m_nodes->autoConnect();
     });
@@ -1446,39 +1444,23 @@ void MainWindow::onDataSavingModeEnabled(bool enabled) {
     qInfo() << "Data Saving Mode" << (enabled ? "enabled" : "disabled");
     
     if (enabled) {
-        // When data saving mode is enabled, pause auto-refresh
         m_wallet->pauseRefresh();
         this->setStatusText("Data Saving Mode enabled - Auto-sync paused", false, 5000);
         QMessageBox::information(this, "Data Saving Mode Enabled",
             "Auto-sync has been disabled to save data.\n\n"
             "Use Wallet > Advanced > Sync Options to:\n"
-            "• Skip Sync - Jump to current height\n"
             "• Sync Dates - Sync a specific date range\n"
             "• Full Sync - Sync normally");
     } else {
-        // When disabled, resume normal sync
         m_wallet->startRefresh();
-        this->setStatusText("Data Saving Mode disabled - Auto-sync resumed", false, 5000);
-    }
-}
-
-void MainWindow::onSkipSync() {
-    auto result = QMessageBox::question(this, "Skip Sync",
-        "This will skip syncing and set your wallet to the current blockchain height.\n\n"
-        "Only use this if you are certain you have NOT received any Monero since your last sync.\n\n"
-        "Continue?");
-    
-    if (result == QMessageBox::Yes) {
-        qInfo() << "User initiated skip sync";
-        m_wallet->skipSync();
-        this->setStatusText("Skip sync initiated", false, 3000);
+        this->setStatusText("Data Saving Mode disabled - Resuming sync", false, 3000);
     }
 }
 
 void MainWindow::onFullSync() {
     qInfo() << "User initiated full sync";
-    m_wallet->startRefresh();
-    this->setStatusText("Full sync started", false, 3000);
+    m_wallet->rescanBlockchainAsync();
+    this->setStatusText("Full sync started - rescanning blockchain", false, 3000);
 }
 
 void MainWindow::onSyncDates() {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -24,6 +24,7 @@
 #include "dialog/ViewOnlyDialog.h"
 #include "dialog/WalletInfoDialog.h"
 #include "dialog/WalletCacheDebugDialog.h"
+#include "dialog/SyncDatesDialog.h"
 #include "libwalletqt/AddressBook.h"
 #include "libwalletqt/rows/CoinsInfo.h"
 #include "libwalletqt/rows/Output.h"
@@ -96,6 +97,7 @@ MainWindow::MainWindow(WindowManager *windowManager, Wallet *wallet, QWidget *pa
     connect(m_windowManager, &WindowManager::offlineMode, this, &MainWindow::onOfflineMode);
     connect(m_windowManager, &WindowManager::manualFeeSelectionEnabled, this, &MainWindow::onManualFeeSelectionEnabled);
     connect(m_windowManager, &WindowManager::subtractFeeFromAmountEnabled, this, &MainWindow::onSubtractFeeFromAmountEnabled);
+    connect(m_windowManager, &WindowManager::dataSavingModeEnabled, this, &MainWindow::onDataSavingModeEnabled);
 
     connect(torManager(), &TorManager::connectionStateChanged, this, &MainWindow::onTorConnectionStateChanged);
     this->onTorConnectionStateChanged(torManager()->torConnected);
@@ -316,6 +318,9 @@ void MainWindow::initMenu() {
     connect(ui->actionRefresh_tabs,          &QAction::triggered, [this]{m_wallet->refreshModels();});
     connect(ui->actionRescan_spent,          &QAction::triggered, this, &MainWindow::rescanSpent);
     connect(ui->actionWallet_cache_debug,    &QAction::triggered, this, &MainWindow::showWalletCacheDebugDialog);
+    connect(ui->actionSkip_sync,             &QAction::triggered, this, &MainWindow::onSkipSync);
+    connect(ui->actionSync_dates,            &QAction::triggered, this, &MainWindow::onSyncDates);
+    connect(ui->actionFull_sync,             &QAction::triggered, this, &MainWindow::onFullSync);
     connect(ui->actionTxPoolViewer,          &QAction::triggered, this, &MainWindow::showTxPoolViewerDialog);
 
     // [Wallet] -> [History]
@@ -1429,6 +1434,53 @@ void MainWindow::importTransaction() {
 
     TxImportDialog dialog(this, m_wallet);
     dialog.exec();
+}
+
+void MainWindow::onDataSavingModeEnabled(bool enabled) {
+    qDebug() << "Data Saving Mode" << (enabled ? "enabled" : "disabled");
+    
+    if (enabled) {
+        // When data saving mode is enabled, pause auto-refresh
+        m_wallet->pauseRefresh();
+        this->setStatusText("Data Saving Mode: Auto-sync disabled", false, 5000);
+    } else {
+        // When disabled, resume normal sync
+        m_wallet->startRefresh();
+        this->setStatusText("Data Saving Mode: Auto-sync enabled", false, 5000);
+    }
+}
+
+void MainWindow::onSkipSync() {
+    auto result = QMessageBox::question(this, "Skip Sync",
+        "This will skip syncing and set your wallet to the current blockchain height.\n\n"
+        "Only use this if you are certain you have NOT received any Monero since your last sync.\n\n"
+        "Continue?");
+    
+    if (result == QMessageBox::Yes) {
+        qInfo() << "User initiated skip sync";
+        m_wallet->skipSync();
+        this->setStatusText("Skip sync initiated", false, 3000);
+    }
+}
+
+void MainWindow::onFullSync() {
+    qInfo() << "User initiated full sync";
+    m_wallet->startRefresh();
+    this->setStatusText("Full sync started", false, 3000);
+}
+
+void MainWindow::onSyncDates() {
+    SyncDatesDialog dialog(this);
+    if (dialog.exec() == QDialog::Accepted) {
+        QDateTime startDate = dialog.getStartDate();
+        QDateTime endDate = dialog.getEndDate();
+        
+        qInfo() << "User initiated date range sync from" << startDate << "to" << endDate;
+        m_wallet->syncDateRange(startDate, endDate);
+        
+        QString msg = QString("Syncing from %1 to %2").arg(startDate.toString("yyyy-MM-dd"), endDate.toString("yyyy-MM-dd"));
+        this->setStatusText(msg, false, 5000);
+    }
 }
 
 void MainWindow::onDeviceError(const QString &error, quint64 errorCode) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1450,7 +1450,8 @@ void MainWindow::onDataSavingModeEnabled(bool enabled) {
             "Auto-sync has been disabled to save data.\n\n"
             "Use Wallet > Advanced > Sync Options to:\n"
             "• Sync Dates - Sync a specific date range\n"
-            "• Full Sync - Sync normally");
+            "• Full Sync - Sync normally\n\n"
+            "Note: Restart the wallet for immediate sync, otherwise wait for the next sync cycle.");
     } else {
         m_wallet->startRefresh();
         this->setStatusText("Data Saving Mode disabled - Resuming sync", false, 3000);
@@ -1459,8 +1460,12 @@ void MainWindow::onDataSavingModeEnabled(bool enabled) {
 
 void MainWindow::onFullSync() {
     qInfo() << "User initiated full sync";
-    m_wallet->rescanBlockchainAsync();
-    this->setStatusText("Full sync started - rescanning blockchain", false, 3000);
+    if (conf()->get(Config::dataSavingMode).toBool()) {
+        conf()->set(Config::dataSavingMode, false);
+        qInfo() << "Data Saving Mode disabled for full sync";
+    }
+    m_wallet->startRefresh();
+    this->setStatusText("Full sync started - syncing from last sync date", false, 3000);
 }
 
 void MainWindow::onSyncDates() {
@@ -1468,6 +1473,11 @@ void MainWindow::onSyncDates() {
     if (dialog.exec() == QDialog::Accepted) {
         QDateTime startDate = dialog.getStartDate();
         QDateTime endDate = dialog.getEndDate();
+        
+        if (conf()->get(Config::dataSavingMode).toBool()) {
+            conf()->set(Config::dataSavingMode, false);
+            qInfo() << "Data Saving Mode disabled for date range sync";
+        }
         
         qInfo() << "User initiated date range sync from" << startDate << "to" << endDate;
         m_wallet->syncDateRange(startDate, endDate);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -117,6 +117,12 @@ MainWindow::MainWindow(WindowManager *windowManager, Wallet *wallet, QWidget *pa
 
     conf()->set(Config::firstRun, false);
 
+    // Check Data Saving Mode before starting wallet sync
+    if (conf()->get(Config::dataSavingMode).toBool()) {
+        m_wallet->pauseRefresh();
+        qInfo() << "Data Saving Mode enabled - auto-sync disabled on wallet open";
+    }
+
     this->onWalletOpened();
 
     connect(&appData()->prices, &Prices::fiatPricesUpdated, this, &MainWindow::updateBalance);
@@ -1437,16 +1443,22 @@ void MainWindow::importTransaction() {
 }
 
 void MainWindow::onDataSavingModeEnabled(bool enabled) {
-    qDebug() << "Data Saving Mode" << (enabled ? "enabled" : "disabled");
+    qInfo() << "Data Saving Mode" << (enabled ? "enabled" : "disabled");
     
     if (enabled) {
         // When data saving mode is enabled, pause auto-refresh
         m_wallet->pauseRefresh();
-        this->setStatusText("Data Saving Mode: Auto-sync disabled", false, 5000);
+        this->setStatusText("Data Saving Mode enabled - Auto-sync paused", false, 5000);
+        QMessageBox::information(this, "Data Saving Mode Enabled",
+            "Auto-sync has been disabled to save data.\n\n"
+            "Use Wallet > Advanced > Sync Options to:\n"
+            "• Skip Sync - Jump to current height\n"
+            "• Sync Dates - Sync a specific date range\n"
+            "• Full Sync - Sync normally");
     } else {
         // When disabled, resume normal sync
         m_wallet->startRefresh();
-        this->setStatusText("Data Saving Mode: Auto-sync enabled", false, 5000);
+        this->setStatusText("Data Saving Mode disabled - Auto-sync resumed", false, 5000);
     }
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -174,9 +174,7 @@ private slots:
     void onSubtractFeeFromAmountEnabled(bool enabled);
     void onMultiBroadcast(const QMap<QString, QString> &txHexMap);
     
-    // Data Saving Mode / Skip Sync
     void onDataSavingModeEnabled(bool enabled);
-    void onSkipSync();
     void onFullSync();
     void onSyncDates();
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -173,6 +173,12 @@ private slots:
     void onManualFeeSelectionEnabled(bool enabled);
     void onSubtractFeeFromAmountEnabled(bool enabled);
     void onMultiBroadcast(const QMap<QString, QString> &txHexMap);
+    
+    // Data Saving Mode / Skip Sync
+    void onDataSavingModeEnabled(bool enabled);
+    void onSkipSync();
+    void onFullSync();
+    void onSyncDates();
 
 private:
     friend WindowManager;

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -542,11 +542,21 @@
      <property name="title">
       <string>Advanced</string>
      </property>
+     <widget class="QMenu" name="menuSync">
+      <property name="title">
+       <string>Sync Options</string>
+      </property>
+      <addaction name="actionSkip_sync"/>
+      <addaction name="actionSync_dates"/>
+      <addaction name="actionFull_sync"/>
+     </widget>
      <addaction name="actionStore_wallet"/>
      <addaction name="actionUpdate_balance"/>
      <addaction name="actionRefresh_tabs"/>
      <addaction name="actionRescan_spent"/>
      <addaction name="actionWallet_cache_debug"/>
+     <addaction name="separator"/>
+     <addaction name="menuSync"/>
     </widget>
     <addaction name="actionInformation"/>
     <addaction name="menuAdvanced"/>
@@ -860,6 +870,30 @@
   <action name="actionWallet_cache_debug">
    <property name="text">
     <string>Wallet cache debug</string>
+   </property>
+  </action>
+  <action name="actionSkip_sync">
+   <property name="text">
+    <string>Skip Sync</string>
+   </property>
+   <property name="toolTip">
+    <string>Skip syncing and jump to current block height (Data Saving Mode)</string>
+   </property>
+  </action>
+  <action name="actionSync_dates">
+   <property name="text">
+    <string>Sync Dates...</string>
+   </property>
+   <property name="toolTip">
+    <string>Sync a specific date range (Data Saving Mode)</string>
+   </property>
+  </action>
+  <action name="actionFull_sync">
+   <property name="text">
+    <string>Full Sync</string>
+   </property>
+   <property name="toolTip">
+    <string>Perform a full wallet synchronization</string>
    </property>
   </action>
   <action name="actionPay_to_many">

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -546,7 +546,6 @@
       <property name="title">
        <string>Sync Options</string>
       </property>
-      <addaction name="actionSkip_sync"/>
       <addaction name="actionSync_dates"/>
       <addaction name="actionFull_sync"/>
      </widget>
@@ -870,14 +869,6 @@
   <action name="actionWallet_cache_debug">
    <property name="text">
     <string>Wallet cache debug</string>
-   </property>
-  </action>
-  <action name="actionSkip_sync">
-   <property name="text">
-    <string>Skip Sync</string>
-   </property>
-   <property name="toolTip">
-    <string>Skip syncing and jump to current block height (Data Saving Mode)</string>
    </property>
   </action>
   <action name="actionSync_dates">

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -364,6 +364,24 @@ void Settings::setupTransactionsTab() {
         conf()->set(Config::subtractFeeFromAmount, toggled);
         emit subtractFeeFromAmountEnabled(toggled);
     });
+
+    // [Data Saving Mode]
+    ui->checkBox_dataSavingMode->setChecked(conf()->get(Config::dataSavingMode).toBool());
+    connect(ui->checkBox_dataSavingMode, &QCheckBox::toggled, [this](bool toggled){
+        conf()->set(Config::dataSavingMode, toggled);
+        emit dataSavingModeEnabled(toggled);
+    });
+    connect(ui->btn_dataSavingInfo, &QPushButton::clicked, [this]{
+        Utils::showInfo(this, "Data Saving Mode", 
+            "Data Saving Mode allows you to save mobile data and time when you haven't received Monero since last opening your wallet.\n\n"
+            "When enabled:\n"
+            "• Wallet will NOT auto-sync on open\n"
+            "• You can use 'Skip Sync' to jump to current block height\n"
+            "• You can use 'Sync Dates' to sync a specific date range\n"
+            "• You can use 'Full Sync' to sync normally\n"
+            "• You can import specific transactions if needed\n\n"
+            "This can save 500+ MB of data and 30+ minutes of syncing time.");
+    });
 }
 
 void Settings::setupPluginsTab() {

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -44,6 +44,7 @@ signals:
     void pluginConfigured(const QString &id);
     void manualFeeSelectionEnabled(bool enabled);
     void subtractFeeFromAmountEnabled(bool enabled);
+    void dataSavingModeEnabled(bool enabled);
 
 public slots:
 //    void checkboxExternalLinkWarn();

--- a/src/SettingsDialog.ui
+++ b/src/SettingsDialog.ui
@@ -1018,6 +1018,43 @@
              </widget>
             </item>
             <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_dataSaving">
+              <item>
+               <widget class="QCheckBox" name="checkBox_dataSavingMode">
+                <property name="text">
+                 <string>Data Saving Mode (Skip auto-sync)</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="btn_dataSavingInfo">
+                <property name="text">
+                 <string>?</string>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>30</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_dataSaving">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
              <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Orientation::Vertical</enum>

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -189,6 +189,7 @@ void WindowManager::showSettings(Nodes *nodes, QWidget *parent, bool showProxyTa
     connect(&settings, &Settings::offlineMode, this, &WindowManager::offlineMode);
     connect(&settings, &Settings::manualFeeSelectionEnabled, this, &WindowManager::manualFeeSelectionEnabled);
     connect(&settings, &Settings::subtractFeeFromAmountEnabled, this, &WindowManager::subtractFeeFromAmountEnabled);
+    connect(&settings, &Settings::dataSavingModeEnabled, this, &WindowManager::dataSavingModeEnabled);
     connect(&settings, &Settings::hideUpdateNotifications, [this](bool hidden){
         for (const auto &window : m_windows) {
             window->onHideUpdateNotifications(hidden);

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -54,6 +54,7 @@ signals:
     void pluginConfigured(const QString &id);
     void manualFeeSelectionEnabled(bool enabled);
     void subtractFeeFromAmountEnabled(bool enabled);
+    void dataSavingModeEnabled(bool enabled);
 
 public slots:
     void onProxySettingsChanged();

--- a/src/dialog/SyncDatesDialog.cpp
+++ b/src/dialog/SyncDatesDialog.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: The Monero Project
+
+#include "SyncDatesDialog.h"
+#include "ui_SyncDatesDialog.h"
+
+#include <QMessageBox>
+
+SyncDatesDialog::SyncDatesDialog(QWidget *parent)
+        : QDialog(parent)
+        , ui(new Ui::SyncDatesDialog)
+{
+    ui->setupUi(this);
+
+    // Set default dates
+    QDateTime now = QDateTime::currentDateTime();
+    ui->dateEdit_start->setDateTime(now.addMonths(-1)); // Default to 1 month ago
+    ui->dateEdit_end->setDateTime(now);
+
+    // Set reasonable date ranges
+    QDateTime genesisTime = QDateTime::fromSecsSinceEpoch(1397818193, Qt::UTC); // Monero genesis
+    ui->dateEdit_start->setMinimumDateTime(genesisTime);
+    ui->dateEdit_start->setMaximumDateTime(now);
+    ui->dateEdit_end->setMinimumDateTime(genesisTime);
+    ui->dateEdit_end->setMaximumDateTime(now);
+
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &SyncDatesDialog::onAccepted);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    this->adjustSize();
+}
+
+QDateTime SyncDatesDialog::getStartDate() const {
+    return m_startDate;
+}
+
+QDateTime SyncDatesDialog::getEndDate() const {
+    return m_endDate;
+}
+
+void SyncDatesDialog::onAccepted() {
+    m_startDate = ui->dateEdit_start->dateTime();
+    m_endDate = ui->dateEdit_end->dateTime();
+
+    if (m_startDate >= m_endDate) {
+        QMessageBox::warning(this, "Invalid Date Range", "Start date must be before end date.");
+        return;
+    }
+
+    this->accept();
+}
+
+SyncDatesDialog::~SyncDatesDialog() = default;

--- a/src/dialog/SyncDatesDialog.h
+++ b/src/dialog/SyncDatesDialog.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: The Monero Project
+
+#ifndef FEATHER_SYNCDATESDIALOG_H
+#define FEATHER_SYNCDATESDIALOG_H
+
+#include <QDialog>
+#include <QDateTime>
+
+namespace Ui {
+    class SyncDatesDialog;
+}
+
+class SyncDatesDialog : public QDialog
+{
+Q_OBJECT
+
+public:
+    explicit SyncDatesDialog(QWidget *parent = nullptr);
+    ~SyncDatesDialog() override;
+
+    QDateTime getStartDate() const;
+    QDateTime getEndDate() const;
+
+private slots:
+    void onAccepted();
+
+private:
+    QScopedPointer<Ui::SyncDatesDialog> ui;
+    QDateTime m_startDate;
+    QDateTime m_endDate;
+};
+
+#endif // FEATHER_SYNCDATESDIALOG_H

--- a/src/dialog/SyncDatesDialog.ui
+++ b/src/dialog/SyncDatesDialog.ui
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SyncDatesDialog</class>
+ <widget class="QDialog" name="SyncDatesDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>250</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Sync Date Range</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_title">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Sync Specific Date Range&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_description">
+     <property name="text">
+      <string>Select the date range to synchronize. The wallet will scan blocks from the start date to the end date.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_1">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_start">
+       <property name="text">
+        <string>Start Date:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QDateTimeEdit" name="dateEdit_start">
+       <property name="calendarPopup">
+        <bool>true</bool>
+       </property>
+       <property name="displayFormat">
+        <string>yyyy-MM-dd hh:mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_end">
+       <property name="text">
+        <string>End Date:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QDateTimeEdit" name="dateEdit_end">
+       <property name="calendarPopup">
+        <bool>true</bool>
+       </property>
+       <property name="displayFormat">
+        <string>yyyy-MM-dd hh:mm</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_info">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic; color:#666666;&quot;&gt;Note: Block heights are estimated based on average 2-minute block time.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -443,13 +443,6 @@ void Wallet::pauseRefresh() {
     m_refreshEnabled = false;
 }
 
-void Wallet::rescanBlockchainAsync() {
-    qInfo() << "Rescanning blockchain from creation height:" << m_originalWalletCreationHeight;
-    m_walletImpl->setRefreshFromBlockHeight(m_originalWalletCreationHeight);
-    m_walletImpl->rescanBlockchainAsync();
-    m_fullSyncRequested.store(true);
-}
-
 void Wallet::syncFromHeight(quint64 height) {
     qInfo() << "Syncing from height:" << height;
     m_walletImpl->setRefreshFromBlockHeight(height);
@@ -496,8 +489,6 @@ void Wallet::startRefreshThread()
                 {
                     m_refreshNow = false;
 
-                    // get daemonHeight and targetHeight
-                    // daemonHeight and targetHeight will be 0 if call to get_info fails
                     quint64 daemonHeight = m_walletImpl->daemonBlockChainHeight();
                     bool success = daemonHeight > 0;
 
@@ -510,8 +501,7 @@ void Wallet::startRefreshThread()
                     emit heightsRefreshed(haveHeights, daemonHeight, targetHeight);
 
                     if (conf()->get(Config::dataSavingMode).toBool()) {
-                        setConnectionStatus(ConnectionStatus_Synchronized);
-                        qInfo() << "Data Saving Mode: Skipping sync, marked synchronized";
+                        qInfo() << "Data Saving Mode: Skipping sync";
                     } else if (haveHeights) {
                         QMutexLocker locker(&m_asyncMutex);
 
@@ -540,9 +530,8 @@ void Wallet::onHeightsRefreshed(bool success, quint64 daemonHeight, quint64 targ
     m_daemonBlockChainTargetHeight = targetHeight;
 
     if (success) {
+        m_heightRefreshFailures = 0;
         quint64 walletHeight = blockChainHeight();
-        
-        qDebug() << "Heights - Wallet:" << walletHeight << "Daemon:" << daemonHeight << "Target:" << targetHeight;
 
         if (conf()->get(Config::dataSavingMode).toBool()) {
             this->syncStatusUpdated(daemonHeight, daemonHeight);
@@ -555,26 +544,19 @@ void Wallet::onHeightsRefreshed(bool success, quint64 daemonHeight, quint64 targ
                 this->syncStatusUpdated(walletHeight, daemonHeight);
             }
 
-            if (m_fullSyncRequested.load()) {
-                quint64 creationHeight = m_originalWalletCreationHeight;
-                if (walletHeight < targetHeight && walletHeight > creationHeight) {
-                    setConnectionStatus(ConnectionStatus_Synchronizing);
-                    qInfo() << "Full sync in progress:" << walletHeight << "/" << targetHeight;
-                } else if (walletHeight >= (targetHeight - 1)) {
-                    m_fullSyncRequested.store(false);
-                    setConnectionStatus(ConnectionStatus_Synchronized);
-                    qInfo() << "Full sync completed";
-                } else {
-                    setConnectionStatus(ConnectionStatus_Synchronizing);
-                }
-            } else if (walletHeight < (targetHeight - 1)) {
+            if (walletHeight < (targetHeight - 1)) {
                 setConnectionStatus(ConnectionStatus_Synchronizing);
             } else {
                 setConnectionStatus(ConnectionStatus_Synchronized);
             }
         }
     } else {
-        if (m_connectionStatus == ConnectionStatus_Disconnected) {
+        m_heightRefreshFailures++;
+        if (m_heightRefreshFailures > 5) {
+            qWarning() << "Heights refresh failed" << m_heightRefreshFailures << "times - disconnecting to try new node";
+            m_heightRefreshFailures = 0;
+            setConnectionStatus(ConnectionStatus_Disconnected);
+        } else if (m_connectionStatus == ConnectionStatus_Disconnected) {
         } else {
             qWarning() << "Heights refresh failed but maintaining connection status" << m_connectionStatus << "- will retry";
         }
@@ -1430,10 +1412,6 @@ quint64 Wallet::getWalletCreationHeight() const {
 
 void Wallet::setWalletCreationHeight(quint64 height) {
     m_wallet2->set_refresh_from_block_height(height);
-}
-
-void Wallet::setFullSyncRequested(bool requested) {
-    m_fullSyncRequested.store(requested);
 }
 
 //! create a view only wallet

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -418,8 +418,7 @@ void Wallet::initAsync(const QString &daemonAddress, bool trustedDaemon, quint64
         setTrustedDaemon(trustedDaemon);
 
         if (success) {
-            qDebug() << "init async finished";
-            qDebug() << "Starting refresh";
+            qDebug() << "init async finished - starting refresh";
             startRefresh();
         }
     });
@@ -487,6 +486,8 @@ void Wallet::startRefreshThread()
                 {
                     m_refreshNow = false;
 
+                    // get daemonHeight and targetHeight
+                                        // daemonHeight and targetHeight will be 0 if call to get_info fails
                     quint64 daemonHeight = m_walletImpl->daemonBlockChainHeight();
                     bool success = daemonHeight > 0;
 
@@ -501,6 +502,8 @@ void Wallet::startRefreshThread()
                     if (conf()->get(Config::dataSavingMode).toBool()) {
                         qInfo() << "Data Saving Mode: Skipping sync";
                     } else if (haveHeights) {
+                        // Don't call refresh function if we don't have the daemon and target height
+                        // We do this to prevent to UI from getting confused about the amount of blocks that are still remaining
                         QMutexLocker locker(&m_asyncMutex);
 
                         if (m_newWallet) {
@@ -620,7 +623,8 @@ void Wallet::onUpdated() {
 
 void Wallet::onRefreshed(bool success, const QString &message) {
     if (!success) {
-        qCritical() << "Refresh failed with error:" << message;
+        // Something went wrong during refresh, in some cases we need to notify the user
+        qCritical() << "Exception during refresh: " << message; // Can't use ->errorString() here, other SLOT might snipe it firstqCritical() << "Refresh failed with error:" << message;
         // Don't disconnect immediately - let the refresh thread retry
         // Only disconnect if we were already disconnected or connecting
         if (m_connectionStatus == ConnectionStatus_Disconnected ||

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -444,17 +444,19 @@ void Wallet::skipSync() {
     // Skip sync by setting wallet height to current daemon height
     quint64 daemonHeight = this->daemonBlockChainHeight();
     if (daemonHeight > 0) {
-        qInfo() << "Skip sync: Setting wallet height to " << daemonHeight;
+        qInfo() << "Skip sync: Setting wallet height to" << daemonHeight;
         m_walletImpl->setRefreshFromBlockHeight(daemonHeight);
-        this->startRefresh();
+        // Trigger one refresh to update wallet state, but don't enable continuous refresh
+        m_refreshNow = true;
     } else {
         qWarning() << "Skip sync failed: Could not get daemon height";
     }
 }
 
 void Wallet::syncFromHeight(quint64 height) {
-    qInfo() << "Syncing from height: " << height;
+    qInfo() << "Syncing from height:" << height;
     m_walletImpl->setRefreshFromBlockHeight(height);
+    // Enable refresh temporarily for this sync operation
     this->startRefresh();
 }
 

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -56,6 +56,8 @@ Wallet::Wallet(Monero::Wallet *wallet, QObject *parent)
     m_walletListener = new WalletListenerImpl(this);
     m_walletImpl->setListener(m_walletListener);
     m_currentSubaddressAccount = getCacheAttribute(ATTRIBUTE_SUBADDRESS_ACCOUNT).toUInt();
+    
+    m_originalWalletCreationHeight = m_walletImpl->getRefreshFromBlockHeight();
 
     m_addressBookModel = new AddressBookModel(this, m_addressBook);
     m_subaddressModel = new SubaddressModel(this, m_subaddress);
@@ -99,7 +101,7 @@ void Wallet::setConnectionStatus(ConnectionStatus value) {
     if (m_connectionStatus == value) {
         return;
     }
-
+    
     m_connectionStatus = value;
     emit connectionStatusChanged(m_connectionStatus);
 }
@@ -418,7 +420,8 @@ void Wallet::initAsync(const QString &daemonAddress, bool trustedDaemon, quint64
         setTrustedDaemon(trustedDaemon);
 
         if (success) {
-            qDebug() << "init async finished - starting refresh";
+            qDebug() << "init async finished";
+            qDebug() << "Starting refresh";
             startRefresh();
         }
     });
@@ -440,17 +443,11 @@ void Wallet::pauseRefresh() {
     m_refreshEnabled = false;
 }
 
-void Wallet::skipSync() {
-    // Skip sync by setting wallet height to current daemon height
-    quint64 daemonHeight = this->daemonBlockChainHeight();
-    if (daemonHeight > 0) {
-        qInfo() << "Skip sync: Setting wallet height to" << daemonHeight;
-        m_walletImpl->setRefreshFromBlockHeight(daemonHeight);
-        // Trigger one refresh to update wallet state, but don't enable continuous refresh
-        m_refreshNow = true;
-    } else {
-        qWarning() << "Skip sync failed: Could not get daemon height";
-    }
+void Wallet::rescanBlockchainAsync() {
+    qInfo() << "Rescanning blockchain from creation height:" << m_originalWalletCreationHeight;
+    m_walletImpl->setRefreshFromBlockHeight(m_originalWalletCreationHeight);
+    m_walletImpl->rescanBlockchainAsync();
+    m_fullSyncRequested.store(true);
 }
 
 void Wallet::syncFromHeight(quint64 height) {
@@ -512,13 +509,13 @@ void Wallet::startRefreshThread()
 
                     emit heightsRefreshed(haveHeights, daemonHeight, targetHeight);
 
-                    // Don't call refresh function if we don't have the daemon and target height
-                    // We do this to prevent to UI from getting confused about the amount of blocks that are still remaining
-                    if (haveHeights) {
+                    if (conf()->get(Config::dataSavingMode).toBool()) {
+                        setConnectionStatus(ConnectionStatus_Synchronized);
+                        qInfo() << "Data Saving Mode: Skipping sync, marked synchronized";
+                    } else if (haveHeights) {
                         QMutexLocker locker(&m_asyncMutex);
 
                         if (m_newWallet) {
-                            // Set blockheight to daemonHeight for newly created wallets to speed up initial sync
                             m_walletImpl->setRefreshFromBlockHeight(daemonHeight);
                             m_newWallet = false;
                         }
@@ -544,21 +541,43 @@ void Wallet::onHeightsRefreshed(bool success, quint64 daemonHeight, quint64 targ
 
     if (success) {
         quint64 walletHeight = blockChainHeight();
+        
+        qDebug() << "Heights - Wallet:" << walletHeight << "Daemon:" << daemonHeight << "Target:" << targetHeight;
 
-        if (daemonHeight < targetHeight) {
-            emit syncStatus(daemonHeight, targetHeight, true);
-        }
-        else {
-            this->syncStatusUpdated(walletHeight, daemonHeight);
-        }
-
-        if (walletHeight < (targetHeight - 1)) {
-            setConnectionStatus(ConnectionStatus_Synchronizing);
-        } else {
+        if (conf()->get(Config::dataSavingMode).toBool()) {
+            this->syncStatusUpdated(daemonHeight, daemonHeight);
             setConnectionStatus(ConnectionStatus_Synchronized);
+        } else {
+            if (daemonHeight < targetHeight) {
+                emit syncStatus(daemonHeight, targetHeight, true);
+            }
+            else {
+                this->syncStatusUpdated(walletHeight, daemonHeight);
+            }
+
+            if (m_fullSyncRequested.load()) {
+                quint64 creationHeight = m_originalWalletCreationHeight;
+                if (walletHeight < targetHeight && walletHeight > creationHeight) {
+                    setConnectionStatus(ConnectionStatus_Synchronizing);
+                    qInfo() << "Full sync in progress:" << walletHeight << "/" << targetHeight;
+                } else if (walletHeight >= (targetHeight - 1)) {
+                    m_fullSyncRequested.store(false);
+                    setConnectionStatus(ConnectionStatus_Synchronized);
+                    qInfo() << "Full sync completed";
+                } else {
+                    setConnectionStatus(ConnectionStatus_Synchronizing);
+                }
+            } else if (walletHeight < (targetHeight - 1)) {
+                setConnectionStatus(ConnectionStatus_Synchronizing);
+            } else {
+                setConnectionStatus(ConnectionStatus_Synchronized);
+            }
         }
     } else {
-        setConnectionStatus(ConnectionStatus_Disconnected);
+        if (m_connectionStatus == ConnectionStatus_Disconnected) {
+        } else {
+            qWarning() << "Heights refresh failed but maintaining connection status" << m_connectionStatus << "- will retry";
+        }
     }
 }
 
@@ -588,6 +607,13 @@ void Wallet::onNewBlock(uint64_t walletHeight) {
     // Called whenever a new block gets scanned by the wallet
     quint64 daemonHeight = m_daemonBlockChainTargetHeight;
 
+    // In Data Saving Mode, always report as synchronized
+    if (conf()->get(Config::dataSavingMode).toBool()) {
+        setConnectionStatus(ConnectionStatus_Synchronized);
+        this->syncStatusUpdated(daemonHeight, daemonHeight);
+        return;
+    }
+
     if (walletHeight < (daemonHeight - 1)) {
         setConnectionStatus(ConnectionStatus_Synchronizing);
     } else {
@@ -614,9 +640,17 @@ void Wallet::onUpdated() {
 
 void Wallet::onRefreshed(bool success, const QString &message) {
     if (!success) {
-        setConnectionStatus(ConnectionStatus_Disconnected);
-        // Something went wrong during refresh, in some cases we need to notify the user
-        qCritical() << "Exception during refresh: " << message; // Can't use ->errorString() here, other SLOT might snipe it first
+        qCritical() << "Refresh failed with error:" << message;
+        // Don't disconnect immediately - let the refresh thread retry
+        // Only disconnect if we were already disconnected or connecting
+        if (m_connectionStatus == ConnectionStatus_Disconnected || 
+            m_connectionStatus == ConnectionStatus_Connecting) {
+            setConnectionStatus(ConnectionStatus_Disconnected);
+        } else {
+            // Keep current connected status but log the error
+            // The refresh thread will retry automatically
+            qWarning() << "Refresh failed but maintaining connection status:" << m_connectionStatus;
+        }
         return;
     }
 
@@ -1391,11 +1425,15 @@ bool Wallet::setRingDatabase(const QString &path) {
 }
 
 quint64 Wallet::getWalletCreationHeight() const {
-    return m_walletImpl->getRefreshFromBlockHeight();
+    return m_originalWalletCreationHeight;
 }
 
 void Wallet::setWalletCreationHeight(quint64 height) {
     m_wallet2->set_refresh_from_block_height(height);
+}
+
+void Wallet::setFullSyncRequested(bool requested) {
+    m_fullSyncRequested.store(requested);
 }
 
 //! create a view only wallet

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -440,6 +440,44 @@ void Wallet::pauseRefresh() {
     m_refreshEnabled = false;
 }
 
+void Wallet::skipSync() {
+    // Skip sync by setting wallet height to current daemon height
+    quint64 daemonHeight = this->daemonBlockChainHeight();
+    if (daemonHeight > 0) {
+        qInfo() << "Skip sync: Setting wallet height to " << daemonHeight;
+        m_walletImpl->setRefreshFromBlockHeight(daemonHeight);
+        this->startRefresh();
+    } else {
+        qWarning() << "Skip sync failed: Could not get daemon height";
+    }
+}
+
+void Wallet::syncFromHeight(quint64 height) {
+    qInfo() << "Syncing from height: " << height;
+    m_walletImpl->setRefreshFromBlockHeight(height);
+    this->startRefresh();
+}
+
+void Wallet::syncDateRange(const QDateTime &startDate, const QDateTime &endDate) {
+    // Monero genesis block timestamp: April 18, 2014 at 10:49:53 AM UTC
+    QDateTime genesisTime = QDateTime::fromSecsSinceEpoch(1397818193, Qt::UTC);
+    
+    // Average Monero block time is ~2 minutes (120 seconds)
+    const quint64 BLOCK_TIME_SECONDS = 120;
+    
+    // Calculate start height
+    qint64 secondsFromGenesis = genesisTime.secsTo(startDate);
+    quint64 startHeight = secondsFromGenesis > 0 ? (secondsFromGenesis / BLOCK_TIME_SECONDS) : 0;
+    
+    qInfo() << "Syncing date range from" << startDate.toString(Qt::ISODate) 
+            << "to" << endDate.toString(Qt::ISODate)
+            << "| Estimated start height:" << startHeight;
+    
+    // Set the start height and begin sync
+    // The wallet will sync until it catches up to the daemon
+    this->syncFromHeight(startHeight);
+}
+
 void Wallet::startRefreshThread()
 {
     const auto future = m_scheduler.run([this] {

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -487,7 +487,7 @@ void Wallet::startRefreshThread()
                     m_refreshNow = false;
 
                     // get daemonHeight and targetHeight
-                                        // daemonHeight and targetHeight will be 0 if call to get_info fails
+                    // daemonHeight and targetHeight will be 0 if call to get_info fails
                     quint64 daemonHeight = m_walletImpl->daemonBlockChainHeight();
                     bool success = daemonHeight > 0;
 
@@ -507,6 +507,7 @@ void Wallet::startRefreshThread()
                         QMutexLocker locker(&m_asyncMutex);
 
                         if (m_newWallet) {
+                            // Set blockheight to daemonHeight for newly created wallets to speed up initial sync
                             m_walletImpl->setRefreshFromBlockHeight(daemonHeight);
                             m_newWallet = false;
                         }
@@ -624,7 +625,7 @@ void Wallet::onUpdated() {
 void Wallet::onRefreshed(bool success, const QString &message) {
     if (!success) {
         // Something went wrong during refresh, in some cases we need to notify the user
-        qCritical() << "Exception during refresh: " << message; // Can't use ->errorString() here, other SLOT might snipe it firstqCritical() << "Refresh failed with error:" << message;
+        qCritical() << "Exception during refresh: " << message; // Can't use ->errorString() here, other SLOT might snipe it first
         // Don't disconnect immediately - let the refresh thread retry
         // Only disconnect if we were already disconnected or connecting
         if (m_connectionStatus == ConnectionStatus_Disconnected ||

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -56,8 +56,6 @@ Wallet::Wallet(Monero::Wallet *wallet, QObject *parent)
     m_walletListener = new WalletListenerImpl(this);
     m_walletImpl->setListener(m_walletListener);
     m_currentSubaddressAccount = getCacheAttribute(ATTRIBUTE_SUBADDRESS_ACCOUNT).toUInt();
-    
-    m_originalWalletCreationHeight = m_walletImpl->getRefreshFromBlockHeight();
 
     m_addressBookModel = new AddressBookModel(this, m_addressBook);
     m_subaddressModel = new SubaddressModel(this, m_subaddress);
@@ -101,7 +99,7 @@ void Wallet::setConnectionStatus(ConnectionStatus value) {
     if (m_connectionStatus == value) {
         return;
     }
-    
+
     m_connectionStatus = value;
     emit connectionStatusChanged(m_connectionStatus);
 }
@@ -453,18 +451,18 @@ void Wallet::syncFromHeight(quint64 height) {
 void Wallet::syncDateRange(const QDateTime &startDate, const QDateTime &endDate) {
     // Monero genesis block timestamp: April 18, 2014 at 10:49:53 AM UTC
     QDateTime genesisTime = QDateTime::fromSecsSinceEpoch(1397818193, Qt::UTC);
-    
+
     // Average Monero block time is ~2 minutes (120 seconds)
     const quint64 BLOCK_TIME_SECONDS = 120;
-    
+
     // Calculate start height
     qint64 secondsFromGenesis = genesisTime.secsTo(startDate);
     quint64 startHeight = secondsFromGenesis > 0 ? (secondsFromGenesis / BLOCK_TIME_SECONDS) : 0;
-    
-    qInfo() << "Syncing date range from" << startDate.toString(Qt::ISODate) 
+
+    qInfo() << "Syncing date range from" << startDate.toString(Qt::ISODate)
             << "to" << endDate.toString(Qt::ISODate)
             << "| Estimated start height:" << startHeight;
-    
+
     // Set the start height and begin sync
     // The wallet will sync until it catches up to the daemon
     this->syncFromHeight(startHeight);
@@ -625,7 +623,7 @@ void Wallet::onRefreshed(bool success, const QString &message) {
         qCritical() << "Refresh failed with error:" << message;
         // Don't disconnect immediately - let the refresh thread retry
         // Only disconnect if we were already disconnected or connecting
-        if (m_connectionStatus == ConnectionStatus_Disconnected || 
+        if (m_connectionStatus == ConnectionStatus_Disconnected ||
             m_connectionStatus == ConnectionStatus_Connecting) {
             setConnectionStatus(ConnectionStatus_Disconnected);
         } else {
@@ -700,7 +698,7 @@ bool Wallet::keyImageSyncNeeded(quint64 amount, bool sendAll) const {
     if (!this->viewOnly()) {
         return false;
     }
-    
+
     if (sendAll) {
         return this->hasUnknownKeyImages();
     }
@@ -1407,7 +1405,7 @@ bool Wallet::setRingDatabase(const QString &path) {
 }
 
 quint64 Wallet::getWalletCreationHeight() const {
-    return m_originalWalletCreationHeight;
+    return m_walletImpl->getRefreshFromBlockHeight();
 }
 
 void Wallet::setWalletCreationHeight(quint64 height) {

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -217,7 +217,6 @@ public:
     // ##### Synchronization (Refresh) #####
     void startRefresh();
     void pauseRefresh();
-    void rescanBlockchainAsync();
     
     //! Sync from specific height
     void syncFromHeight(quint64 height);
@@ -412,7 +411,6 @@ public:
 
     quint64 getWalletCreationHeight() const;
     void setWalletCreationHeight(quint64 height);
-    void setFullSyncRequested(bool requested);
 
     //! Rescan spent outputs
     bool rescanSpent();
@@ -534,8 +532,8 @@ private:
     bool m_useSSL;
     bool m_newWallet = false;
     bool m_forceKeyImageSync = false;
-    std::atomic<bool> m_fullSyncRequested{false};
     quint64 m_originalWalletCreationHeight = 0;
+    int m_heightRefreshFailures = 0;
 
     QTimer *m_storeTimer = nullptr;
     std::set<std::string> m_selectedInputs;

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -217,6 +217,15 @@ public:
     // ##### Synchronization (Refresh) #####
     void startRefresh();
     void pauseRefresh();
+    
+    //! Skip sync - sync from current daemon height (for data saving mode)
+    void skipSync();
+    
+    //! Sync from specific height
+    void syncFromHeight(quint64 height);
+    
+    //! Sync from date range (converts dates to block heights)
+    void syncDateRange(const QDateTime &startDate, const QDateTime &endDate);
 
     //! returns current wallet's block height
     //! (can be less than daemon's blockchain height when wallet sync in progress)

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -142,7 +142,7 @@ public:
     bool isDeterministic() const;
 
     QString walletName() const;
-    
+
     // ##### Balance #####
     //! returns balance
     quint64 balance() const;
@@ -153,7 +153,7 @@ public:
     quint64 unlockedBalance() const;
     quint64 unlockedBalance(quint32 accountIndex) const;
     quint64 unlockedBalanceAll() const;
-    
+
     quint64 viewOnlyBalance(quint32 accountIndex) const;
 
     void updateBalance();
@@ -217,10 +217,10 @@ public:
     // ##### Synchronization (Refresh) #####
     void startRefresh();
     void pauseRefresh();
-    
+
     //! Sync from specific height
     void syncFromHeight(quint64 height);
-    
+
     //! Sync from date range (converts dates to block heights)
     void syncDateRange(const QDateTime &startDate, const QDateTime &endDate);
 
@@ -256,19 +256,19 @@ public:
     void setForceKeyImageSync(bool enabled);
     bool hasUnknownKeyImages() const;
     bool keyImageSyncNeeded(quint64 amount, bool sendAll) const;
-    
+
     //! export/import key images
     bool exportKeyImages(const QString& path, bool all = false);
     bool exportKeyImagesToStr(std::string &keyImages, bool all = false);
     bool exportKeyImagesForOutputsFromStr(const std::string &outputs, std::string &keyImages);
-    
+
     bool importKeyImages(const QString& path);
     bool importKeyImagesFromStr(const std::string &keyImages);
 
     //! export/import outputs
     bool exportOutputs(const QString& path, bool all = false);
     bool exportOutputsToStr(std::string& outputs, bool all);
-    
+
     bool importOutputs(const QString& path);
     bool importOutputsFromStr(const std::string &outputs);
 
@@ -348,7 +348,7 @@ public:
     //! Sign a transfer from file
     UnsignedTransaction * loadTxFile(const QString &fileName);
     UnsignedTransaction * loadUnsignedTransactionFromStr(const std::string &data);
-    
+
     //! Load an unsigned transaction from a base64 encoded string
     UnsignedTransaction * loadTxFromBase64Str(const QString &unsigned_tx);
 
@@ -532,7 +532,6 @@ private:
     bool m_useSSL;
     bool m_newWallet = false;
     bool m_forceKeyImageSync = false;
-    quint64 m_originalWalletCreationHeight = 0;
     int m_heightRefreshFailures = 0;
 
     QTimer *m_storeTimer = nullptr;

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -217,9 +217,7 @@ public:
     // ##### Synchronization (Refresh) #####
     void startRefresh();
     void pauseRefresh();
-    
-    //! Skip sync - sync from current daemon height (for data saving mode)
-    void skipSync();
+    void rescanBlockchainAsync();
     
     //! Sync from specific height
     void syncFromHeight(quint64 height);
@@ -414,6 +412,7 @@ public:
 
     quint64 getWalletCreationHeight() const;
     void setWalletCreationHeight(quint64 height);
+    void setFullSyncRequested(bool requested);
 
     //! Rescan spent outputs
     bool rescanSpent();
@@ -535,6 +534,8 @@ private:
     bool m_useSSL;
     bool m_newWallet = false;
     bool m_forceKeyImageSync = false;
+    std::atomic<bool> m_fullSyncRequested{false};
+    quint64 m_originalWalletCreationHeight = 0;
 
     QTimer *m_storeTimer = nullptr;
     std::set<std::string> m_selectedInputs;

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -84,6 +84,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
         {Config::offlineTxSigningForceKISync, {QS("offlineTxSigningForceKISync"), false}},
         {Config::manualFeeTierSelection, {QS("manualFeeTierSelection"), false}},
         {Config::subtractFeeFromAmount, {QS("subtractFeeFromAmount"), false}},
+        {Config::dataSavingMode, {QS("dataSavingMode"), false}},
 
         {Config::warnOnExternalLink,{QS("warnOnExternalLink"), true}},
         {Config::hideBalance, {QS("hideBalance"), false}},

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -115,6 +115,7 @@ public:
         offlineTxSigningForceKISync,
         manualFeeTierSelection,
         subtractFeeFromAmount,
+        dataSavingMode,
 
         // Misc
         blockExplorers,

--- a/src/utils/nodes.cpp
+++ b/src/utils/nodes.cpp
@@ -424,6 +424,10 @@ void Nodes::onWalletRefreshed() {
         if (m_connection.isOnion())
             return;
 
+        // Don't reconnect if we have a working connection (clearnet is fine if already synced)
+        if (m_connection.isActive)
+            return;
+
         this->autoConnect(true);
     }
 }


### PR DESCRIPTION
This PR adds a Data Saving Mode feature to help users reduce bandwidth usage by preventing automatic blockchain synchronization.
More info : [add-a-skip-sync-feature-to-a-monero-wallet](https://bounties.monero.social/posts/79/1-230m-add-a-skip-sync-feature-to-a-monero-wallet)
### Features Added

**1. Data Saving Mode**
- Optional setting to disable automatic blockchain sync
- Wallet marks as synchronized without downloading blocks
- Accessible via Settings checkbox
- Can be toggled on/off at runtime

**2. Full Sync**
- Syncs from last sync date to current blockchain height
- Automatically disables Data Saving Mode when triggered
- Estimated ~500 MB of data
- Available in: Wallet → Advanced → Full Sync

**3. Sync Dates**
- Sync specific date ranges (e.g., April 1 - April 8)
- Automatically disables Data Saving Mode when used
- Available in: Wallet → Advanced → Sync Dates

### Technical Implementation

- Preserves wallet's natural blockchain height (no permanent modifications)
- Proper connection status handling to prevent reconnection loops
- Auto node failover after consecutive connection failures
- Prevents unnecessary Tor node switching when connection is stable
- Clean implementation following Feather's design patterns

### Use Cases

- Users on metered/limited bandwidth connections
- Quick wallet access without waiting for full sync
- Verify balance without downloading entire blockchain
- Sync only relevant date ranges when needed

### Testing

Tested on Debian 10 with Qt6, multiple node types (clearnet and .onion), and various sync scenarios.