### PR TITLE
macOS: recover UI after sleep using NSWorkspace wake notifications

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,11 @@ file(GLOB SOURCE_FILES
         "plugins/*.h"
         )
 
+if(APPLE)
+    list(APPEND SOURCE_FILES
+            "utils/os/macos_sleep.mm")
+endif()
+
 get_cmake_property(_vars VARIABLES)
 set(PLUGIN_PREFIX "WITH_PLUGIN_")
 

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -7,6 +7,7 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QWindow>
+#include <QTimer>
 
 #include "Application.h"
 #include "constants.h"
@@ -41,6 +42,9 @@ WindowManager::WindowManager(QObject *parent)
 
     connect(qApp, SIGNAL(anotherInstanceStarted()), this, SLOT(raise()));
     connect(qApp, &QGuiApplication::lastWindowClosed, this, &WindowManager::quitAfterLastWindow);
+#if defined(Q_OS_MACOS)
+    connect(qApp, &QGuiApplication::applicationStateChanged, this, &WindowManager::onApplicationStateChanged);
+#endif
 
     m_tray = new QSystemTrayIcon(icons()->icon("appicons/64x64.png"));
     m_tray->setToolTip("Feather Wallet");
@@ -619,6 +623,59 @@ void WindowManager::onWalletPassphraseNeeded(bool on_device) {
     bool ok;
     QString passphrase = QInputDialog::getText(nullptr, "Wallet Passphrase Needed", "Enter passphrase:", QLineEdit::EchoMode::Password, "", &ok);
     m_walletManager->onPassphraseEntered(passphrase, false, false);
+}
+
+void WindowManager::onApplicationStateChanged(Qt::ApplicationState state) {
+#if defined(Q_OS_MACOS)
+    if (state == Qt::ApplicationInactive || state == Qt::ApplicationHidden) {
+        m_inactiveTimer.start();
+        return;
+    }
+
+    if (state == Qt::ApplicationActive && m_inactiveTimer.isValid()) {
+        // Only run recovery after longer inactivity (sleep/wake) to avoid normal app switches.
+        constexpr qint64 wakeThresholdMs = 60 * 1000;
+        const qint64 inactiveMs = m_inactiveTimer.elapsed();
+        m_inactiveTimer.invalidate();
+        if (inactiveMs >= wakeThresholdMs) {
+            QTimer::singleShot(0, this, &WindowManager::recoverFromSleep);
+        }
+    }
+#else
+    Q_UNUSED(state);
+#endif
+}
+
+void WindowManager::recoverFromSleep() {
+#if defined(Q_OS_MACOS)
+    // Recreate tray icon to work around macOS Qt status item issues after sleep.
+    const bool trayVisible = conf()->get(Config::showTrayIcon).toBool();
+    if (m_tray) {
+        m_tray->setVisible(false);
+        delete m_tray;
+        m_tray = nullptr;
+    }
+
+    m_tray = new QSystemTrayIcon(icons()->icon("appicons/64x64.png"));
+    m_tray->setToolTip("Feather Wallet");
+    this->buildTrayMenu();
+    m_tray->setVisible(trayVisible);
+
+    for (const auto &window : m_windows) {
+        if (!window) {
+            continue;
+        }
+        if (!window->isHidden()) {
+            window->bringToFront();
+        } else {
+            window->update();
+        }
+    }
+    if (m_wizard && !m_wizard->isHidden()) {
+        m_wizard->raise();
+        m_wizard->activateWindow();
+    }
+#endif
 }
 
 // ######################## TRAY ########################

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -7,7 +7,11 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QWindow>
+
+#if defined(Q_OS_MACOS)
+#include "utils/os/macos_sleep.h"
 #include <QTimer>
+#endif
 
 #include "Application.h"
 #include "constants.h"
@@ -43,7 +47,10 @@ WindowManager::WindowManager(QObject *parent)
     connect(qApp, SIGNAL(anotherInstanceStarted()), this, SLOT(raise()));
     connect(qApp, &QGuiApplication::lastWindowClosed, this, &WindowManager::quitAfterLastWindow);
 #if defined(Q_OS_MACOS)
-    connect(qApp, &QGuiApplication::applicationStateChanged, this, &WindowManager::onApplicationStateChanged);
+    m_macSleepObserver = new MacSleepObserver(this);
+    connect(m_macSleepObserver, &MacSleepObserver::didWake, this, [this] {
+        QTimer::singleShot(0, this, &WindowManager::recoverFromSleep);
+    });
 #endif
 
     m_tray = new QSystemTrayIcon(icons()->icon("appicons/64x64.png"));
@@ -623,27 +630,6 @@ void WindowManager::onWalletPassphraseNeeded(bool on_device) {
     bool ok;
     QString passphrase = QInputDialog::getText(nullptr, "Wallet Passphrase Needed", "Enter passphrase:", QLineEdit::EchoMode::Password, "", &ok);
     m_walletManager->onPassphraseEntered(passphrase, false, false);
-}
-
-void WindowManager::onApplicationStateChanged(Qt::ApplicationState state) {
-#if defined(Q_OS_MACOS)
-    if (state == Qt::ApplicationInactive || state == Qt::ApplicationHidden) {
-        m_inactiveTimer.start();
-        return;
-    }
-
-    if (state == Qt::ApplicationActive && m_inactiveTimer.isValid()) {
-        // Only run recovery after longer inactivity (sleep/wake) to avoid normal app switches.
-        constexpr qint64 wakeThresholdMs = 60 * 1000;
-        const qint64 inactiveMs = m_inactiveTimer.elapsed();
-        m_inactiveTimer.invalidate();
-        if (inactiveMs >= wakeThresholdMs) {
-            QTimer::singleShot(0, this, &WindowManager::recoverFromSleep);
-        }
-    }
-#else
-    Q_UNUSED(state);
-#endif
 }
 
 void WindowManager::recoverFromSleep() {

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 #include <QSystemTrayIcon>
+#include <QElapsedTimer>
 
 #include "utils/EventFilter.h"
 #include "utils/nodes.h"
@@ -71,6 +72,8 @@ private slots:
     void onDeviceError(const QString &errorMessage, quint64 errorCode);
     void onWalletPassphraseNeeded(bool on_device);
     void onChangeTheme(const QString &themeName);
+    void onApplicationStateChanged(Qt::ApplicationState state);
+    void recoverFromSleep();
 
 private:
     void tryCreateWallet(Seed seed, const QString &path, const QString &password, const QString &seedLanguage, const QString &seedOffset, const QString &subaddressLookahead, bool newWallet);
@@ -115,6 +118,8 @@ private:
     bool m_initialNetworkConfigured = false;
 
     QThread *m_cleanupThread;
+
+    QElapsedTimer m_inactiveTimer;
 };
 
 inline WindowManager* windowManager()

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -6,7 +6,6 @@
 
 #include <QObject>
 #include <QSystemTrayIcon>
-#include <QElapsedTimer>
 
 #include "utils/EventFilter.h"
 #include "utils/nodes.h"
@@ -72,7 +71,6 @@ private slots:
     void onDeviceError(const QString &errorMessage, quint64 errorCode);
     void onWalletPassphraseNeeded(bool on_device);
     void onChangeTheme(const QString &themeName);
-    void onApplicationStateChanged(Qt::ApplicationState state);
     void recoverFromSleep();
 
 private:
@@ -118,8 +116,9 @@ private:
     bool m_initialNetworkConfigured = false;
 
     QThread *m_cleanupThread;
-
-    QElapsedTimer m_inactiveTimer;
+#if defined(Q_OS_MACOS)
+    class MacSleepObserver *m_macSleepObserver = nullptr;
+#endif
 };
 
 inline WindowManager* windowManager()

--- a/src/utils/os/macos_sleep.h
+++ b/src/utils/os/macos_sleep.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: The Monero Project
+
+#ifndef FEATHER_MACOS_SLEEP_H
+#define FEATHER_MACOS_SLEEP_H
+
+#include <QObject>
+
+class MacSleepObserver : public QObject {
+    Q_OBJECT
+
+public:
+    explicit MacSleepObserver(QObject *parent = nullptr);
+    ~MacSleepObserver() override;
+
+    void notifyWillSleep();
+    void notifyDidWake();
+
+signals:
+    void willSleep();
+    void didWake();
+
+private:
+    void *m_observer = nullptr;
+};
+
+#endif // FEATHER_MACOS_SLEEP_H

--- a/src/utils/os/macos_sleep.mm
+++ b/src/utils/os/macos_sleep.mm
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: The Monero Project
+
+#include "macos_sleep.h"
+
+#if defined(Q_OS_MACOS)
+
+#import <Cocoa/Cocoa.h>
+
+@interface FeatherSleepObserver : NSObject
+@property (nonatomic, assign) MacSleepObserver *owner;
+@end
+
+@implementation FeatherSleepObserver
+- (instancetype)initWithOwner:(MacSleepObserver *)owner {
+    self = [super init];
+    if (self) {
+        _owner = owner;
+        NSNotificationCenter *center = [[NSWorkspace sharedWorkspace] notificationCenter];
+        [center addObserver:self selector:@selector(onWillSleep:) name:NSWorkspaceWillSleepNotification object:nil];
+        [center addObserver:self selector:@selector(onDidWake:) name:NSWorkspaceDidWakeNotification object:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    NSNotificationCenter *center = [[NSWorkspace sharedWorkspace] notificationCenter];
+    [center removeObserver:self];
+#if !__has_feature(objc_arc)
+    [super dealloc];
+#endif
+}
+
+- (void)onWillSleep:(NSNotification *)__unused notification {
+    if (_owner) {
+        _owner->notifyWillSleep();
+    }
+}
+
+- (void)onDidWake:(NSNotification *)__unused notification {
+    if (_owner) {
+        _owner->notifyDidWake();
+    }
+}
+@end
+
+MacSleepObserver::MacSleepObserver(QObject *parent)
+    : QObject(parent)
+{
+    FeatherSleepObserver *observer = [[FeatherSleepObserver alloc] initWithOwner:this];
+#if __has_feature(objc_arc)
+    m_observer = (__bridge_retained void *)observer;
+#else
+    m_observer = observer;
+#endif
+}
+
+MacSleepObserver::~MacSleepObserver() {
+    if (m_observer) {
+#if !__has_feature(objc_arc)
+        FeatherSleepObserver *observer = static_cast<FeatherSleepObserver *>(m_observer);
+        [observer release];
+#else
+        CFBridgingRelease(m_observer);
+#endif
+        m_observer = nullptr;
+    }
+}
+
+void MacSleepObserver::notifyWillSleep() {
+    emit willSleep();
+}
+
+void MacSleepObserver::notifyDidWake() {
+    emit didWake();
+}
+
+#else
+
+MacSleepObserver::MacSleepObserver(QObject *parent)
+    : QObject(parent)
+{}
+
+MacSleepObserver::~MacSleepObserver() = default;
+
+void MacSleepObserver::notifyWillSleep() {}
+
+void MacSleepObserver::notifyDidWake() {}
+
+#endif


### PR DESCRIPTION
### Problem
On macOS after a long sleep, Feather may hang with a spinning cursor when clicked from the tray and never show a window. Force quit + relaunch is required.

### Repro
1. Launch Feather on macOS.
2. Put the system to sleep for a long period.
3. Wake the system and click the Feather tray icon.
4. The app becomes unresponsive; no window appears.

### Fix
Subscribe to native macOS sleep/wake notifications (NSWorkspaceWillSleep/DidWake) via a small Objective-C++ observer and trigger UI recovery on wake. This avoids heuristics and ensures recovery runs only on actual wake events.

### Notes
- macOS-only; no changes to other platforms.
- Workaround for tray/UI not resuming correctly after sleep.