### PR TITLE
doc: documentation updates for torPrivacyLevel as well as multiple other important user safety and privacy areas of code. 

### DIFF
--- a/src/utils/TorManager.cpp
+++ b/src/utils/TorManager.cpp
@@ -84,6 +84,10 @@ void TorManager::start() {
 
     qDebug() << QString("Start process: %1").arg(this->torPath);
 
+    // Limit restart attempts to prevent infinite loops when Tor is misconfigured.
+    // After 4 failed attempts, Tor is permanently disabled for this session.
+    // The error is emitted via statusChanged() but there is no UI dialog — the user
+    // sees Tor as disconnected in the status bar.
     m_restarts += 1;
     if (m_restarts > 4) {
         this->setErrorMessage("Tor failed to start: maximum retries exceeded");
@@ -105,8 +109,15 @@ void TorManager::start() {
     m_started = true;
 }
 
+// Checks whether Tor is connected. Called every 5 seconds by m_checkConnectionTimer.
+// The check varies by environment (order matters — first match wins):
+//   1. Torsocks:  Assume connected (can't probe localhost through torsocks)
+//   2. Whonix:    Assume connected (Whonix guarantees all traffic is routed through Tor)
+//   3. Tails:     Query systemd for "tails-tor-has-bootstrapped.target"
+//   4. Non-Tor:   Not connected (proxy isn't set to Tor)
+//   5. Local Tor: Probe user-configured socks5Host:socks5Port (default 127.0.0.1:9050)
+//   6. Managed:   Probe featherTorHost:featherTorPort (default 127.0.0.1:19450)
 void TorManager::checkConnection() {
-    // We might not be able to connect to localhost if torsocks is used to start feather
     if (Utils::isTorsocks()) {
         this->setConnectionState(true);
     }
@@ -142,6 +153,10 @@ void TorManager::setConnectionState(bool connected) {
     emit connectionStateChanged(connected);
 }
 
+// Called when the managed Tor process changes state.
+// If Tor exits unexpectedly (crash, killed), it is automatically restarted after 1 second
+// unless m_stopRetries is set (which happens when the binary fails to start at all).
+// The restart goes through start(), which enforces the 4-attempt limit via m_restarts.
 void TorManager::stateChanged(QProcess::ProcessState state) {
     if (state == QProcess::ProcessState::Running) {
         this->setErrorMessage("");
@@ -248,6 +263,17 @@ bool TorManager::isAlreadyRunning() {
     return m_alreadyRunning;
 }
 
+// Determines whether Feather should start its own managed Tor daemon.
+// Returns false (use external Tor) when any of these conditions are met:
+//   - Running under torsocks (detected via LD_PRELOAD / DYLD_INSERT_LIBRARIES)
+//   - Running on Tails or Whonix (these OSes manage their own Tor)
+//   - Built without embedded Tor binary (no HAS_TOR_BIN or TOR_INSTALLED)
+//   - Proxy is not set to Tor
+//   - --use-local-tor flag or useLocalTor config is set
+//   - A Tor daemon is already listening on socks5Port (default 9050)
+//   - A service is already listening on featherTorPort (default 19450), sets m_alreadyRunning
+// Sets m_alreadyRunning = true if port 19450 is occupied, causing checkConnection()
+// to probe that port instead of socks5Port.
 bool TorManager::shouldStartTorDaemon() {
     QString torHost = conf()->get(Config::socks5Host).toString();
     quint16 torPort = conf()->get(Config::socks5Port).toString().toUShort();
@@ -259,7 +285,7 @@ bool TorManager::shouldStartTorDaemon() {
         return false;
     }
 
-    // Don't start a Tor daemon on privacy OSes
+    // Don't start a Tor daemon on privacy OSes (they manage their own Tor instance)
     if (TailsOS::detect() || WhonixOS::detect()) {
         return false;
     }

--- a/src/utils/TorManager.h
+++ b/src/utils/TorManager.h
@@ -29,8 +29,14 @@ public:
 
     static TorManager* instance();
 
-    bool torConnected = false;
+    bool torConnected = false;  // True after Tor bootstraps (100%) or is assumed connected
+                                // (torsocks/Whonix/Tails). Checked every 5s by checkConnection().
 
+    // Host and port for Feather's MANAGED Tor daemon. This is separate from the user-configured
+    // socks5Host:socks5Port (default 9050) to avoid port conflicts with a system Tor daemon.
+    // When connecting to a node, the proxy address is chosen in Nodes::connectToNode():
+    //   - Managed Tor (or m_alreadyRunning): uses featherTorHost:featherTorPort
+    //   - Local/system Tor: uses socks5Host:socks5Port from config
     QString featherTorHost = "127.0.0.1";
     quint16 featherTorPort = 19450;
 
@@ -60,13 +66,18 @@ private:
     static QPointer<TorManager> m_instance;
 
     QProcess *m_process;
-    int m_restarts = 0;
-    bool m_stopRetries = false;
-    bool m_localTor = false;
-    bool m_started = false;
-    bool m_unpacked = false;
-    bool m_alreadyRunning = false;
-    QTimer *m_checkConnectionTimer;
+    int m_restarts = 0;          // Number of start() attempts. If > 4, Tor gives up permanently
+                                 // with "maximum retries exceeded" and no further user notification.
+    bool m_stopRetries = false;  // Set to true on FailedToStart error. Prevents automatic restart
+                                 // via stateChanged() when the binary itself is missing/broken.
+    bool m_localTor = false;     // True when using system Tor (not managed). Set by init() based
+                                 // on shouldStartTorDaemon(). Affects which port checkConnection() probes.
+    bool m_started = false;      // True after start() launches the managed Tor process.
+    bool m_unpacked = false;     // True after embedded Tor binary has been extracted to disk.
+    bool m_alreadyRunning = false; // True if featherTorPort (19450) was already occupied when
+                                   // shouldStartTorDaemon() ran. Causes checkConnection() to probe
+                                   // that port instead of socks5Port.
+    QTimer *m_checkConnectionTimer; // Fires every 5 seconds to call checkConnection().
 };
 
 inline TorManager* torManager()

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -112,7 +112,18 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
         {Config::cryptoSymbols, {QS("cryptoSymbols"), QStringList{"BTC", "ETH", "LTC", "XMR", "ZEC"}}},
 
         // Tor
+        //
+        // proxy: connection method (0 = None, 1 = Tor, 2 = i2p, 3 = SOCKS5)
         {Config::proxy, {QS("proxy"), Config::Proxy::Tor}},
+        //
+        // torPrivacyLevel: controls how node traffic is routed when using Tor.
+        //   0 (allTorExceptNode)     - All traffic through Tor, except node communication (clearnet nodes allowed).
+        //                              Fastest, but a remote node can see your IP address.
+        //   1 (allTorExceptInitSync) - All traffic through Tor, but clearnet nodes are allowed during initial
+        //                              blockchain sync until the wallet is within `initSyncThreshold` blocks of
+        //                              the network height. After that, only .onion nodes are used. (default)
+        //   2 (allTor)               - All node traffic routed through Tor unconditionally (.onion nodes only).
+        //                              Maximum privacy, but initial sync may be significantly slower.
         {Config::torPrivacyLevel, {QS("torPrivacyLevel"), 1}},
         {Config::torOnlyAllowOnion, {QS("torOnlyAllowOnion"), false}},
         {Config::socks5Host, {QS("socks5Host"), "127.0.0.1"}},
@@ -121,6 +132,9 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
         {Config::socks5Pass, {QS("socks5Pass"), ""}}, // Unused
         {Config::torManagedPort, {QS("torManagedPort"), "19450"}},
         {Config::useLocalTor, {QS("useLocalTor"), false}},
+        // initSyncThreshold: number of blocks from the network tip. When torPrivacyLevel is 1
+        // (allTorExceptInitSync), the wallet switches to .onion-only nodes once it is within
+        // this many blocks of the current network height.
         {Config::initSyncThreshold, {QS("initSyncThreshold"), 360}},
 
         {Config::enabledPlugins, {QS("enabledPlugins"), QStringList{"tickers", "crowdfunding", "revuo", "calc"}}},

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -125,12 +125,23 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
         //   2 (allTor)               - All node traffic routed through Tor unconditionally (.onion nodes only).
         //                              Maximum privacy, but initial sync may be significantly slower.
         {Config::torPrivacyLevel, {QS("torPrivacyLevel"), 1}},
+        //
+        // torOnlyAllowOnion: when true, forces .onion-only node connections regardless of
+        // torPrivacyLevel. This is a separate override — setting torPrivacyLevel to 0
+        // (allTorExceptNode) while this is true will still force .onion-only connections.
         {Config::torOnlyAllowOnion, {QS("torOnlyAllowOnion"), false}},
         {Config::socks5Host, {QS("socks5Host"), "127.0.0.1"}},
+        // socks5Port: port for system/local Tor daemon (default 9050). Used when useLocalTor
+        // is true or when a system Tor is detected. See also: torManagedPort.
         {Config::socks5Port, {QS("socks5Port"), "9050"}},
-        {Config::socks5User, {QS("socks5User"), ""}}, // Unused
-        {Config::socks5Pass, {QS("socks5Pass"), ""}}, // Unused
+        {Config::socks5User, {QS("socks5User"), ""}}, // Unused — stored but never sent to proxy
+        {Config::socks5Pass, {QS("socks5Pass"), ""}}, // Unused — stored but never sent to proxy
+        // torManagedPort: port for Feather's own managed Tor daemon (default 19450). Used when
+        // Feather starts its bundled Tor binary. This is separate from socks5Port to avoid
+        // conflicting with a system Tor daemon that may already be running on port 9050.
         {Config::torManagedPort, {QS("torManagedPort"), "19450"}},
+        // useLocalTor: when true, Feather will not start a bundled Tor daemon and instead
+        // expects a Tor daemon to already be running at socks5Host:socks5Port.
         {Config::useLocalTor, {QS("useLocalTor"), false}},
         // initSyncThreshold: number of blocks from the network tip. When torPrivacyLevel is 1
         // (allTorExceptInitSync), the wallet switches to .onion-only nodes once it is within

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -141,10 +141,14 @@ public:
         tickersShowFiatBalance,
     };
 
+    // Controls how node network traffic is routed when using Tor (see: torPrivacyLevel config key).
+    // Determines whether Feather connects to .onion nodes exclusively or allows clearnet nodes.
+    // Used by Nodes::useOnionNodes() to decide connection strategy.
     enum PrivacyLevel {
-        allTorExceptNode = 0,
-        allTorExceptInitSync,
-        allTor
+        allTorExceptNode = 0,       // Route all traffic through Tor except node communication (clearnet nodes allowed)
+        allTorExceptInitSync,       // Route all traffic through Tor, but allow clearnet nodes during initial sync
+                                    // until blockchain height is within initSyncThreshold of network height
+        allTor                      // Route all node traffic through Tor unconditionally (onion nodes only)
     };
 
     enum BalanceDisplay {

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -79,8 +79,8 @@ public:
         socks5User,
         socks5Pass,
         useLocalTor, // Prevents Feather from starting bundled Tor daemon
-        torOnlyAllowOnion,
-        torPrivacyLevel, // Tor node network traffic strategy
+        torOnlyAllowOnion, // If true, overrides torPrivacyLevel and forces .onion-only node connections
+        torPrivacyLevel, // Tor node network traffic strategy (see PrivacyLevel enum below)
         torManagedPort, // Port for managed Tor daemon
         initSyncThreshold, // Switch to Tor after initial sync threshold blocks
 

--- a/src/utils/nodes.cpp
+++ b/src/utils/nodes.cpp
@@ -212,9 +212,11 @@ void Nodes::connectToNode(const FeatherNode &node) {
         return;
     }
 
+    // When torOnlyAllowOnion is enabled, reject non-onion nodes (local nodes are exempt).
+    // This is a hard filter independent of torPrivacyLevel — even if privacy level allows
+    // clearnet, this checkbox blocks it.
     if (conf()->get(Config::proxy).toInt() == Config::Proxy::Tor && conf()->get(Config::torOnlyAllowOnion).toBool()) {
         if (!node.isOnion() && !node.isLocal()) {
-            // We only want to connect to .onion nodes, but local nodes get an exception.
             return;
         }
     }
@@ -228,6 +230,9 @@ void Nodes::connectToNode(const FeatherNode &node) {
     // Don't use SSL over Tor/i2p
     m_wallet->setUseSSL(!node.isAnonymityNetwork());
 
+    // Select the SOCKS5 proxy address based on which Tor daemon is in use:
+    //   - Managed Tor or m_alreadyRunning: use featherTorHost:featherTorPort (default 127.0.0.1:19450)
+    //   - Local/system Tor or non-Tor proxy: use socks5Host:socks5Port (default 127.0.0.1:9050)
     QString proxyAddress;
     if (useSocks5Proxy(node)) {
         if (conf()->get(Config::proxy).toInt() == Config::Proxy::Tor && (!torManager()->isLocalTor() || torManager()->isAlreadyRunning())) {
@@ -414,13 +419,19 @@ void Nodes::setCustomNodes(const QList<FeatherNode> &nodes) {
     this->updateModels();
 }
 
+// Called after every wallet refresh (sync cycle). Implements the automatic clearnet-to-onion
+// transition for the allTorExceptInitSync privacy level:
+//   - If connected to a local node: do nothing (local traffic is never routed through Tor)
+//   - If already on an .onion node: do nothing (already private)
+//   - Otherwise: force reconnect via autoConnect(), which calls pickEligibleNode().
+//     If useOnionNodes() now returns true (wallet is synced past initSyncThreshold),
+//     pickEligibleNode() will only return .onion nodes, completing the transition.
+// This reconnection happens silently — there is no UI notification to the user.
 void Nodes::onWalletRefreshed() {
     if (conf()->get(Config::proxy) == Config::Proxy::Tor && conf()->get(Config::torPrivacyLevel).toInt() == Config::allTorExceptInitSync) {
-        // Don't reconnect if we're connected to a local node (traffic will not be routed through Tor)
         if (m_connection.isLocal())
             return;
 
-        // Don't reconnect if we're already connected to an .onion node
         if (m_connection.isOnion())
             return;
 
@@ -428,11 +439,27 @@ void Nodes::onWalletRefreshed() {
     }
 }
 
+// Determines whether Feather should connect exclusively to .onion nodes.
+// Returns true when any of these conditions are met (checked in order):
+//   1. torOnlyAllowOnion is enabled — this overrides torPrivacyLevel entirely
+//   2. torPrivacyLevel == allTor (2) — always use .onion nodes
+//   3. torPrivacyLevel == allTorExceptInitSync (1) AND the wallet has completed
+//      at least one refresh cycle (refreshedOnce), OR the wallet's blockchain height
+//      is within initSyncThreshold blocks of the network height
+// Returns false when:
+//   - Proxy is not set to Tor
+//   - torPrivacyLevel == allTorExceptNode (0)
+//   - torPrivacyLevel == allTorExceptInitSync (1) and wallet is still syncing
+// This function is called by websocketNodes() to filter the node list, by useSocks5Proxy()
+// to decide whether to route through the SOCKS5 proxy, and indirectly by onWalletRefreshed()
+// to trigger the clearnet-to-onion transition.
 bool Nodes::useOnionNodes() {
     if (conf()->get(Config::proxy) != Config::Proxy::Tor) {
         return false;
     }
 
+    // torOnlyAllowOnion overrides torPrivacyLevel — if this checkbox is enabled,
+    // only .onion nodes are used regardless of privacy level setting.
     if (conf()->get(Config::torOnlyAllowOnion).toBool()) {
         return true;
     }
@@ -494,7 +521,9 @@ bool Nodes::useSocks5Proxy(const FeatherNode &node) {
     }
 
     if (config_proxy == Config::Proxy::Tor) {
-        // Don't use socks5 proxy if initial sync traffic is excluded.
+        // Use the SOCKS5 proxy only when connecting to .onion nodes.
+        // When useOnionNodes() is false (e.g. during initial sync in allTorExceptInitSync mode,
+        // or always in allTorExceptNode mode), clearnet nodes are connected directly.
         return this->useOnionNodes();
     }
 

--- a/src/utils/os/tails.h
+++ b/src/utils/os/tails.h
@@ -6,9 +6,18 @@
 
 #include <QString>
 
+// Tails OS detection and integration.
+// When Tails is detected, Feather changes Tor-related behavior:
+//   - TorManager will NOT start a managed Tor daemon (Tails runs its own)
+//   - TorManager::checkConnection() verifies Tor status by checking the systemd target
+//     "tails-tor-has-bootstrapped.target" via /bin/systemctl
+//   - Nodes::useSocks5Proxy() returns true (Tails does not transparently route all traffic)
+//   - Config directory defaults to ~/Persistent/feather_data if persistence is enabled
 class TailsOS
 {
 public:
+    // Detects Tails by checking /etc/os-release for TAILS_PRODUCT_NAME or NAME="Tails".
+    // Result is cached after first call.
     static bool detect();
     static bool detectDataPersistence();
     static bool detectDotPersistence();

--- a/src/utils/os/whonix.cpp
+++ b/src/utils/os/whonix.cpp
@@ -5,6 +5,8 @@
 
 #include "utils/Utils.h"
 
+// Detection relies on the WHONIX environment variable, which is set by Whonix's
+// /etc/profile.d scripts. Any non-empty value triggers detection.
 bool WhonixOS::detect() {
     return !QString::fromLocal8Bit(qgetenv("WHONIX")).isEmpty();
 }

--- a/src/utils/os/whonix.h
+++ b/src/utils/os/whonix.h
@@ -6,7 +6,13 @@
 
 #include <QString>
 
+// Whonix OS detection.
+// When Whonix is detected, Feather assumes Tor is already running and connected:
+//   - TorManager will NOT start a managed Tor daemon
+//   - TorManager::checkConnection() assumes Tor is connected without verification
+//   - Nodes::useSocks5Proxy() returns true (Whonix does not transparently proxy all traffic)
 struct WhonixOS {
+    // Returns true if the WHONIX environment variable is set (any non-empty value).
     static bool detect();
     static QString version();
 };


### PR DESCRIPTION
## Summary

Document previously-undocumented Tor subsystem behaviors:

- Add comments to the `PrivacyLevel` enum in `config.h` explaining each value and its effect on node traffic routing
- Document `torPrivacyLevel`, `torOnlyAllowOnion`, `socks5Port`, `torManagedPort`, `useLocalTor`, and `initSyncThreshold` settings.json keys in `config.cpp`
- Document Whonix/Tails/torsocks auto-detection and its effects on Tor daemon management (`whonix.h`, `whonix.cpp`, `tails.h`)
- Document TorManager restart limit (max 4 attempts), silent failure mode, and all private member variables (`TorManager.h`, `TorManager.cpp`)
- Document `checkConnection()` priority order (6 code paths) and `shouldStartTorDaemon()` return conditions
- Document `stateChanged()` auto-restart behavior after Tor crash
- Document automatic clearnet-to-onion reconnection on wallet refresh in `onWalletRefreshed()`
- Document `useOnionNodes()` full decision tree including `torOnlyAllowOnion` override
- Document dual port architecture: managed Tor on 19450 vs system Tor on 9050
- Document proxy address selection logic in `connectToNode()`
- Fix misleading comment in `useSocks5Proxy()`

This addresses the MAINTENANCE.md goal of documenting default settings.

Companion PR: https://github.com/feather-wallet/feather-docs/pull/18

## Test plan

- [ ] Documentation-only change (comments), no functional impact