### PR TITLE
Wallet: clear tmpTxDescription in sweepOutputs

### DIFF
--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -929,6 +929,8 @@ void Wallet::createTransactionMultiDest(const QVector<QString> &addresses, const
 }
 
 void Wallet::sweepOutputs(const QVector<QString> &keyImages, QString address, bool churn, int outputs, int feeLevel) {
+    this->tmpTxDescription = "";
+
     if (churn) {
         address = this->address(m_currentSubaddressAccount, 0);
     }


### PR DESCRIPTION
## Summary

`sweepOutputs` never reset `tmpTxDescription` before building a transaction, so the description from a previous `createTransaction` or `createTransactionMultiDest` call would bleed through into the sweep confirmation dialog and `commitTransaction`.

The fix mirrors the one-liner already present in both other transaction creation functions:

```cpp
this->tmpTxDescription = "";
```

Fixes #299.