### PR TITLE
wizard: add option to hide seed passphrase

### DIFF
--- a/src/wizard/PageSetSeedPassphrase.cpp
+++ b/src/wizard/PageSetSeedPassphrase.cpp
@@ -5,6 +5,8 @@
 #include "ui_PageSetSeedPassphrase.h"
 #include "WalletWizard.h"
 
+#include <QCheckBox>
+
 PageSetSeedPassphrase::PageSetSeedPassphrase(WizardFields *fields, QWidget *parent)
     : QWizardPage(parent)
     , ui(new Ui::PageSetSeedPassphrase)
@@ -13,10 +15,16 @@ PageSetSeedPassphrase::PageSetSeedPassphrase(WizardFields *fields, QWidget *pare
     ui->setupUi(this);
 
     this->setTitle("Seed Passphrase");
+
+    connect(ui->check_hidePassphrase, &QCheckBox::clicked, [this](bool checked){
+        ui->linePassphrase->setEchoMode(checked ? QLineEdit::Password : QLineEdit::Normal);
+    });
 }
 
 void PageSetSeedPassphrase::initializePage() {
     ui->linePassphrase->setText("");
+    ui->check_hidePassphrase->setChecked(true);
+    ui->linePassphrase->setEchoMode(QLineEdit::Password);
 }
 
 bool PageSetSeedPassphrase::validatePage() {

--- a/src/wizard/PageSetSeedPassphrase.ui
+++ b/src/wizard/PageSetSeedPassphrase.ui
@@ -45,7 +45,21 @@
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="linePassphrase"/>
+    <widget class="QLineEdit" name="linePassphrase">
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="check_hidePassphrase">
+     <property name="text">
+      <string>Hide passphrase</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QLabel" name="label_4">


### PR DESCRIPTION
Adds a checkbox option to hide the seed offset passphrase when restoring a wallet.